### PR TITLE
Fix 4.2 guzzle compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,12 @@ https://github.com/catalyst/moodle-tool_objectfs
 
 ## Supported Moodle Versions
 
-This plugin requires Moodle 2.6+
+| Branch           | Version support | Notes                                                                                                         |
+| ---------------- | --------------- | ------------------------------------------------------------------------------------------------------------- |
+| MOODLE_42_STABLE | 4.2 +           | Uses an older re-namespaced version of the GuzzleHttp library, due to conflicts with core GuzzleHttp in 4.2+  |
+| master           | 2.6 - 4.1       |                                                                                                               |
+
+Since 17 March 2024 the Azure storage PHP SDK this plugin uses was deprecated and is no longer being maintained. While the API may still work, it is not officially being supported and will slowly become more incompatible with newer versions of PHP. This plugin is not actively maintained.
 
 ## Installation
 

--- a/readme_moodle.txt
+++ b/readme_moodle.txt
@@ -7,3 +7,10 @@ To update the contents of this plugin.
 * git add -f vendor
 * update the version details in version.php
 * update the version details in thirdpartylibs.xml
+
+For Moodle 4.2+
+=======================
+Moodle 4.2 includes GuzzleHttp in core, and is a higher version with breaking API changes. Additional steps are required to re-namespace the guzzle included here to maintain parallel compatibility.
+
+1. Replace all `*.php` files `GuzzleHttp` with `GuzzleHttpLocal`
+2. In `vendor/composer/autoload_psr4.php` modify the `GuzzleHttp` keys in the class map array, and change them to be `GuzzleHttpLocal`

--- a/vendor/composer/autoload_psr4.php
+++ b/vendor/composer/autoload_psr4.php
@@ -8,7 +8,7 @@ $baseDir = dirname($vendorDir);
 return array(
     'Psr\\Http\\Message\\' => array($vendorDir . '/psr/http-message/src'),
     'MicrosoftAzure\\Storage\\' => array($vendorDir . '/microsoft/azure-storage/src'),
-    'GuzzleHttp\\Psr7\\' => array($vendorDir . '/guzzlehttp/psr7/src'),
-    'GuzzleHttp\\Promise\\' => array($vendorDir . '/guzzlehttp/promises/src'),
-    'GuzzleHttp\\' => array($vendorDir . '/guzzlehttp/guzzle/src'),
+    'GuzzleHttpLocal\\Psr7\\' => array($vendorDir . '/guzzlehttp/psr7/src'),
+    'GuzzleHttpLocal\\Promise\\' => array($vendorDir . '/guzzlehttp/promises/src'),
+    'GuzzleHttpLocal\\' => array($vendorDir . '/guzzlehttp/guzzle/src'),
 );

--- a/vendor/guzzlehttp/guzzle/src/Client.php
+++ b/vendor/guzzlehttp/guzzle/src/Client.php
@@ -1,9 +1,9 @@
 <?php
-namespace GuzzleHttp;
+namespace GuzzleHttpLocal;
 
-use GuzzleHttp\Cookie\CookieJar;
-use GuzzleHttp\Promise;
-use GuzzleHttp\Psr7;
+use GuzzleHttpLocal\Cookie\CookieJar;
+use GuzzleHttpLocal\Promise;
+use GuzzleHttpLocal\Psr7;
 use Psr\Http\Message\UriInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -45,7 +45,7 @@ class Client implements ClientInterface
      * - handler: (callable) Function that transfers HTTP requests over the
      *   wire. The function is called with a Psr7\Http\Message\RequestInterface
      *   and array of transfer options, and must return a
-     *   GuzzleHttp\Promise\PromiseInterface that is fulfilled with a
+     *   GuzzleHttpLocal\Promise\PromiseInterface that is fulfilled with a
      *   Psr7\Http\Message\ResponseInterface on success. "handler" is a
      *   constructor only option that cannot be overridden in per/request
      *   options. If no handler is provided, a default handler will be created
@@ -57,7 +57,7 @@ class Client implements ClientInterface
      *
      * @param array $config Client configuration settings.
      *
-     * @see \GuzzleHttp\RequestOptions for a list of available request options.
+     * @see \GuzzleHttpLocal\RequestOptions for a list of available request options.
      */
     public function __construct(array $config = [])
     {
@@ -311,7 +311,7 @@ class Client implements ClientInterface
         }
 
         if (isset($options['json'])) {
-            $options['body'] = \GuzzleHttp\json_encode($options['json']);
+            $options['body'] = \GuzzleHttpLocal\json_encode($options['json']);
             unset($options['json']);
             $options['_conditional']['Content-Type'] = 'application/json';
         }

--- a/vendor/guzzlehttp/guzzle/src/ClientInterface.php
+++ b/vendor/guzzlehttp/guzzle/src/ClientInterface.php
@@ -1,8 +1,8 @@
 <?php
-namespace GuzzleHttp;
+namespace GuzzleHttpLocal;
 
-use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttpLocal\Promise\PromiseInterface;
+use GuzzleHttpLocal\Exception\GuzzleException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;

--- a/vendor/guzzlehttp/guzzle/src/Cookie/CookieJar.php
+++ b/vendor/guzzlehttp/guzzle/src/Cookie/CookieJar.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Cookie;
+namespace GuzzleHttpLocal\Cookie;
 
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;

--- a/vendor/guzzlehttp/guzzle/src/Cookie/CookieJarInterface.php
+++ b/vendor/guzzlehttp/guzzle/src/Cookie/CookieJarInterface.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Cookie;
+namespace GuzzleHttpLocal\Cookie;
 
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;

--- a/vendor/guzzlehttp/guzzle/src/Cookie/FileCookieJar.php
+++ b/vendor/guzzlehttp/guzzle/src/Cookie/FileCookieJar.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Cookie;
+namespace GuzzleHttpLocal\Cookie;
 
 /**
  * Persists non-session cookies using a JSON formatted file
@@ -55,7 +55,7 @@ class FileCookieJar extends CookieJar
             }
         }
 
-        $jsonStr = \GuzzleHttp\json_encode($json);
+        $jsonStr = \GuzzleHttpLocal\json_encode($json);
         if (false === file_put_contents($filename, $jsonStr)) {
             throw new \RuntimeException("Unable to save file {$filename}");
         }
@@ -78,7 +78,7 @@ class FileCookieJar extends CookieJar
             return;
         }
 
-        $data = \GuzzleHttp\json_decode($json, true);
+        $data = \GuzzleHttpLocal\json_decode($json, true);
         if (is_array($data)) {
             foreach (json_decode($json, true) as $cookie) {
                 $this->setCookie(new SetCookie($cookie));

--- a/vendor/guzzlehttp/guzzle/src/Cookie/SessionCookieJar.php
+++ b/vendor/guzzlehttp/guzzle/src/Cookie/SessionCookieJar.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Cookie;
+namespace GuzzleHttpLocal\Cookie;
 
 /**
  * Persists cookies in the client session

--- a/vendor/guzzlehttp/guzzle/src/Cookie/SetCookie.php
+++ b/vendor/guzzlehttp/guzzle/src/Cookie/SetCookie.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Cookie;
+namespace GuzzleHttpLocal\Cookie;
 
 /**
  * Set-Cookie object

--- a/vendor/guzzlehttp/guzzle/src/Exception/BadResponseException.php
+++ b/vendor/guzzlehttp/guzzle/src/Exception/BadResponseException.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Exception;
+namespace GuzzleHttpLocal\Exception;
 
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;

--- a/vendor/guzzlehttp/guzzle/src/Exception/ClientException.php
+++ b/vendor/guzzlehttp/guzzle/src/Exception/ClientException.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Exception;
+namespace GuzzleHttpLocal\Exception;
 
 /**
  * Exception when a client error is encountered (4xx codes)

--- a/vendor/guzzlehttp/guzzle/src/Exception/ConnectException.php
+++ b/vendor/guzzlehttp/guzzle/src/Exception/ConnectException.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Exception;
+namespace GuzzleHttpLocal\Exception;
 
 use Psr\Http\Message\RequestInterface;
 

--- a/vendor/guzzlehttp/guzzle/src/Exception/GuzzleException.php
+++ b/vendor/guzzlehttp/guzzle/src/Exception/GuzzleException.php
@@ -1,4 +1,4 @@
 <?php
-namespace GuzzleHttp\Exception;
+namespace GuzzleHttpLocal\Exception;
 
 interface GuzzleException {}

--- a/vendor/guzzlehttp/guzzle/src/Exception/RequestException.php
+++ b/vendor/guzzlehttp/guzzle/src/Exception/RequestException.php
@@ -1,9 +1,9 @@
 <?php
-namespace GuzzleHttp\Exception;
+namespace GuzzleHttpLocal\Exception;
 
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttpLocal\Promise\PromiseInterface;
 use Psr\Http\Message\UriInterface;
 
 /**

--- a/vendor/guzzlehttp/guzzle/src/Exception/SeekException.php
+++ b/vendor/guzzlehttp/guzzle/src/Exception/SeekException.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Exception;
+namespace GuzzleHttpLocal\Exception;
 
 use Psr\Http\Message\StreamInterface;
 

--- a/vendor/guzzlehttp/guzzle/src/Exception/ServerException.php
+++ b/vendor/guzzlehttp/guzzle/src/Exception/ServerException.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Exception;
+namespace GuzzleHttpLocal\Exception;
 
 /**
  * Exception when a server error is encountered (5xx codes)

--- a/vendor/guzzlehttp/guzzle/src/Exception/TooManyRedirectsException.php
+++ b/vendor/guzzlehttp/guzzle/src/Exception/TooManyRedirectsException.php
@@ -1,4 +1,4 @@
 <?php
-namespace GuzzleHttp\Exception;
+namespace GuzzleHttpLocal\Exception;
 
 class TooManyRedirectsException extends RequestException {}

--- a/vendor/guzzlehttp/guzzle/src/Exception/TransferException.php
+++ b/vendor/guzzlehttp/guzzle/src/Exception/TransferException.php
@@ -1,4 +1,4 @@
 <?php
-namespace GuzzleHttp\Exception;
+namespace GuzzleHttpLocal\Exception;
 
 class TransferException extends \RuntimeException implements GuzzleException {}

--- a/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php
+++ b/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php
@@ -1,13 +1,13 @@
 <?php
-namespace GuzzleHttp\Handler;
+namespace GuzzleHttpLocal\Handler;
 
-use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Promise\FulfilledPromise;
-use GuzzleHttp\Promise\RejectedPromise;
-use GuzzleHttp\Psr7;
-use GuzzleHttp\Psr7\LazyOpenStream;
-use GuzzleHttp\TransferStats;
+use GuzzleHttpLocal\Exception\RequestException;
+use GuzzleHttpLocal\Exception\ConnectException;
+use GuzzleHttpLocal\Promise\FulfilledPromise;
+use GuzzleHttpLocal\Promise\RejectedPromise;
+use GuzzleHttpLocal\Psr7;
+use GuzzleHttpLocal\Psr7\LazyOpenStream;
+use GuzzleHttpLocal\TransferStats;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -88,7 +88,7 @@ class CurlFactory implements CurlFactoryInterface
      * @param EasyHandle           $easy
      * @param CurlFactoryInterface $factory Dictates how the handle is released
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public static function finish(
         callable $handler,
@@ -163,7 +163,7 @@ class CurlFactory implements CurlFactoryInterface
         // If an exception was encountered during the onHeaders event, then
         // return a rejected promise that wraps that exception.
         if ($easy->onHeadersException) {
-            return \GuzzleHttp\Promise\rejection_for(
+            return \GuzzleHttpLocal\Promise\rejection_for(
                 new RequestException(
                     'An error was encountered during the on_headers event',
                     $easy->request,
@@ -186,7 +186,7 @@ class CurlFactory implements CurlFactoryInterface
             ? new ConnectException($message, $easy->request, null, $ctx)
             : new RequestException($message, $easy->request, $easy->response, null, $ctx);
 
-        return \GuzzleHttp\Promise\rejection_for($error);
+        return \GuzzleHttpLocal\Promise\rejection_for($error);
     }
 
     private function getDefaultConf(EasyHandle $easy)
@@ -358,7 +358,7 @@ class CurlFactory implements CurlFactoryInterface
         if (isset($options['sink'])) {
             $sink = $options['sink'];
             if (!is_string($sink)) {
-                $sink = \GuzzleHttp\Psr7\stream_for($sink);
+                $sink = \GuzzleHttpLocal\Psr7\stream_for($sink);
             } elseif (!is_dir(dirname($sink))) {
                 // Ensure that the directory exists before failing in curl.
                 throw new \RuntimeException(sprintf(
@@ -410,7 +410,7 @@ class CurlFactory implements CurlFactoryInterface
                 if (isset($options['proxy'][$scheme])) {
                     $host = $easy->request->getUri()->getHost();
                     if (!isset($options['proxy']['no']) ||
-                        !\GuzzleHttp\is_host_in_noproxy($host, $options['proxy']['no'])
+                        !\GuzzleHttpLocal\is_host_in_noproxy($host, $options['proxy']['no'])
                     ) {
                         $conf[CURLOPT_PROXY] = $options['proxy'][$scheme];
                     }
@@ -465,7 +465,7 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         if (!empty($options['debug'])) {
-            $conf[CURLOPT_STDERR] = \GuzzleHttp\debug_resource($options['debug']);
+            $conf[CURLOPT_STDERR] = \GuzzleHttpLocal\debug_resource($options['debug']);
             $conf[CURLOPT_VERBOSE] = true;
         }
     }

--- a/vendor/guzzlehttp/guzzle/src/Handler/CurlFactoryInterface.php
+++ b/vendor/guzzlehttp/guzzle/src/Handler/CurlFactoryInterface.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Handler;
+namespace GuzzleHttpLocal\Handler;
 
 use Psr\Http\Message\RequestInterface;
 

--- a/vendor/guzzlehttp/guzzle/src/Handler/CurlHandler.php
+++ b/vendor/guzzlehttp/guzzle/src/Handler/CurlHandler.php
@@ -1,7 +1,7 @@
 <?php
-namespace GuzzleHttp\Handler;
+namespace GuzzleHttpLocal\Handler;
 
-use GuzzleHttp\Psr7;
+use GuzzleHttpLocal\Psr7;
 use Psr\Http\Message\RequestInterface;
 
 /**

--- a/vendor/guzzlehttp/guzzle/src/Handler/CurlMultiHandler.php
+++ b/vendor/guzzlehttp/guzzle/src/Handler/CurlMultiHandler.php
@@ -1,9 +1,9 @@
 <?php
-namespace GuzzleHttp\Handler;
+namespace GuzzleHttpLocal\Handler;
 
-use GuzzleHttp\Promise as P;
-use GuzzleHttp\Promise\Promise;
-use GuzzleHttp\Psr7;
+use GuzzleHttpLocal\Promise as P;
+use GuzzleHttpLocal\Promise\Promise;
+use GuzzleHttpLocal\Psr7;
 use Psr\Http\Message\RequestInterface;
 
 /**

--- a/vendor/guzzlehttp/guzzle/src/Handler/EasyHandle.php
+++ b/vendor/guzzlehttp/guzzle/src/Handler/EasyHandle.php
@@ -1,7 +1,7 @@
 <?php
-namespace GuzzleHttp\Handler;
+namespace GuzzleHttpLocal\Handler;
 
-use GuzzleHttp\Psr7\Response;
+use GuzzleHttpLocal\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
@@ -50,8 +50,8 @@ final class EasyHandle
 
         // HTTP-version SP status-code SP reason-phrase
         $startLine = explode(' ', array_shift($this->headers), 3);
-        $headers = \GuzzleHttp\headers_from_lines($this->headers);
-        $normalizedKeys = \GuzzleHttp\normalize_header_keys($headers);
+        $headers = \GuzzleHttpLocal\headers_from_lines($this->headers);
+        $normalizedKeys = \GuzzleHttpLocal\normalize_header_keys($headers);
 
         if (!empty($this->options['decode_content'])
             && isset($normalizedKeys['content-encoding'])

--- a/vendor/guzzlehttp/guzzle/src/Handler/MockHandler.php
+++ b/vendor/guzzlehttp/guzzle/src/Handler/MockHandler.php
@@ -1,11 +1,11 @@
 <?php
-namespace GuzzleHttp\Handler;
+namespace GuzzleHttpLocal\Handler;
 
-use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Promise\RejectedPromise;
-use GuzzleHttp\TransferStats;
+use GuzzleHttpLocal\Exception\RequestException;
+use GuzzleHttpLocal\HandlerStack;
+use GuzzleHttpLocal\Promise\PromiseInterface;
+use GuzzleHttpLocal\Promise\RejectedPromise;
+use GuzzleHttpLocal\TransferStats;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -91,8 +91,8 @@ class MockHandler implements \Countable
         }
 
         $response = $response instanceof \Exception
-            ? \GuzzleHttp\Promise\rejection_for($response)
-            : \GuzzleHttp\Promise\promise_for($response);
+            ? \GuzzleHttpLocal\Promise\rejection_for($response)
+            : \GuzzleHttpLocal\Promise\promise_for($response);
 
         return $response->then(
             function ($value) use ($request, $options) {
@@ -120,7 +120,7 @@ class MockHandler implements \Countable
                 if ($this->onRejected) {
                     call_user_func($this->onRejected, $reason);
                 }
-                return \GuzzleHttp\Promise\rejection_for($reason);
+                return \GuzzleHttpLocal\Promise\rejection_for($reason);
             }
         );
     }
@@ -140,7 +140,7 @@ class MockHandler implements \Countable
                 $this->queue[] = $value;
             } else {
                 throw new \InvalidArgumentException('Expected a response or '
-                    . 'exception. Found ' . \GuzzleHttp\describe_type($value));
+                    . 'exception. Found ' . \GuzzleHttpLocal\describe_type($value));
             }
         }
     }

--- a/vendor/guzzlehttp/guzzle/src/Handler/Proxy.php
+++ b/vendor/guzzlehttp/guzzle/src/Handler/Proxy.php
@@ -1,7 +1,7 @@
 <?php
-namespace GuzzleHttp\Handler;
+namespace GuzzleHttpLocal\Handler;
 
-use GuzzleHttp\RequestOptions;
+use GuzzleHttpLocal\RequestOptions;
 use Psr\Http\Message\RequestInterface;
 
 /**

--- a/vendor/guzzlehttp/guzzle/src/Handler/StreamHandler.php
+++ b/vendor/guzzlehttp/guzzle/src/Handler/StreamHandler.php
@@ -1,13 +1,13 @@
 <?php
-namespace GuzzleHttp\Handler;
+namespace GuzzleHttpLocal\Handler;
 
-use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Promise\FulfilledPromise;
-use GuzzleHttp\Promise\RejectedPromise;
-use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7;
-use GuzzleHttp\TransferStats;
+use GuzzleHttpLocal\Exception\RequestException;
+use GuzzleHttpLocal\Exception\ConnectException;
+use GuzzleHttpLocal\Promise\FulfilledPromise;
+use GuzzleHttpLocal\Promise\RejectedPromise;
+use GuzzleHttpLocal\Promise\PromiseInterface;
+use GuzzleHttpLocal\Psr7;
+use GuzzleHttpLocal\TransferStats;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
@@ -67,7 +67,7 @@ class StreamHandler
             $e = RequestException::wrapException($request, $e);
             $this->invokeStats($options, $request, $startTime, null, $e);
 
-            return \GuzzleHttp\Promise\rejection_for($e);
+            return \GuzzleHttpLocal\Promise\rejection_for($e);
         }
     }
 
@@ -102,7 +102,7 @@ class StreamHandler
         $ver = explode('/', $parts[0])[1];
         $status = $parts[1];
         $reason = isset($parts[2]) ? $parts[2] : null;
-        $headers = \GuzzleHttp\headers_from_lines($hdrs);
+        $headers = \GuzzleHttpLocal\headers_from_lines($hdrs);
         list ($stream, $headers) = $this->checkDecode($options, $headers, $stream);
         $stream = Psr7\stream_for($stream);
         $sink = $stream;
@@ -119,7 +119,7 @@ class StreamHandler
             } catch (\Exception $e) {
                 $msg = 'An error was encountered during the on_headers event';
                 $ex = new RequestException($msg, $request, $response, $e);
-                return \GuzzleHttp\Promise\rejection_for($ex);
+                return \GuzzleHttpLocal\Promise\rejection_for($ex);
             }
         }
 
@@ -157,7 +157,7 @@ class StreamHandler
     {
         // Automatically decode responses when instructed.
         if (!empty($options['decode_content'])) {
-            $normalizedKeys = \GuzzleHttp\normalize_header_keys($headers);
+            $normalizedKeys = \GuzzleHttpLocal\normalize_header_keys($headers);
             if (isset($normalizedKeys['content-encoding'])) {
                 $encoding = $headers[$normalizedKeys['content-encoding']];
                 if ($encoding[0] === 'gzip' || $encoding[0] === 'deflate') {
@@ -401,7 +401,7 @@ class StreamHandler
             $scheme = $request->getUri()->getScheme();
             if (isset($value[$scheme])) {
                 if (!isset($value['no'])
-                    || !\GuzzleHttp\is_host_in_noproxy(
+                    || !\GuzzleHttpLocal\is_host_in_noproxy(
                         $request->getUri()->getHost(),
                         $value['no']
                     )
@@ -425,7 +425,7 @@ class StreamHandler
             // PHP 5.6 or greater will find the system cert by default. When
             // < 5.6, use the Guzzle bundled cacert.
             if (PHP_VERSION_ID < 50600) {
-                $options['ssl']['cafile'] = \GuzzleHttp\default_ca_bundle();
+                $options['ssl']['cafile'] = \GuzzleHttpLocal\default_ca_bundle();
             }
         } elseif (is_string($value)) {
             $options['ssl']['cafile'] = $value;
@@ -492,7 +492,7 @@ class StreamHandler
         static $args = ['severity', 'message', 'message_code',
             'bytes_transferred', 'bytes_max'];
 
-        $value = \GuzzleHttp\debug_resource($value);
+        $value = \GuzzleHttpLocal\debug_resource($value);
         $ident = $request->getMethod() . ' ' . $request->getUri()->withFragment('');
         $this->addNotification(
             $params,

--- a/vendor/guzzlehttp/guzzle/src/HandlerStack.php
+++ b/vendor/guzzlehttp/guzzle/src/HandlerStack.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp;
+namespace GuzzleHttpLocal;
 
 use Psr\Http\Message\RequestInterface;
 

--- a/vendor/guzzlehttp/guzzle/src/MessageFormatter.php
+++ b/vendor/guzzlehttp/guzzle/src/MessageFormatter.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp;
+namespace GuzzleHttpLocal;
 
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;

--- a/vendor/guzzlehttp/guzzle/src/Middleware.php
+++ b/vendor/guzzlehttp/guzzle/src/Middleware.php
@@ -1,10 +1,10 @@
 <?php
-namespace GuzzleHttp;
+namespace GuzzleHttpLocal;
 
-use GuzzleHttp\Cookie\CookieJarInterface;
-use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Promise\RejectedPromise;
-use GuzzleHttp\Psr7;
+use GuzzleHttpLocal\Cookie\CookieJarInterface;
+use GuzzleHttpLocal\Exception\RequestException;
+use GuzzleHttpLocal\Promise\RejectedPromise;
+use GuzzleHttpLocal\Psr7;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
@@ -29,7 +29,7 @@ final class Middleware
                 if (empty($options['cookies'])) {
                     return $handler($request, $options);
                 } elseif (!($options['cookies'] instanceof CookieJarInterface)) {
-                    throw new \InvalidArgumentException('cookies must be an instance of GuzzleHttp\Cookie\CookieJarInterface');
+                    throw new \InvalidArgumentException('cookies must be an instance of GuzzleHttpLocal\Cookie\CookieJarInterface');
                 }
                 $cookieJar = $options['cookies'];
                 $request = $cookieJar->withCookieHeader($request);
@@ -102,7 +102,7 @@ final class Middleware
                             'error'    => $reason,
                             'options'  => $options
                         ];
-                        return \GuzzleHttp\Promise\rejection_for($reason);
+                        return \GuzzleHttpLocal\Promise\rejection_for($reason);
                     }
                 );
             };
@@ -198,7 +198,7 @@ final class Middleware
                             : null;
                         $message = $formatter->format($request, $response, $reason);
                         $logger->notice($message);
-                        return \GuzzleHttp\Promise\rejection_for($reason);
+                        return \GuzzleHttpLocal\Promise\rejection_for($reason);
                     }
                 );
             };

--- a/vendor/guzzlehttp/guzzle/src/Pool.php
+++ b/vendor/guzzlehttp/guzzle/src/Pool.php
@@ -1,9 +1,9 @@
 <?php
-namespace GuzzleHttp;
+namespace GuzzleHttpLocal;
 
-use GuzzleHttp\Promise\PromisorInterface;
+use GuzzleHttpLocal\Promise\PromisorInterface;
 use Psr\Http\Message\RequestInterface;
-use GuzzleHttp\Promise\EachPromise;
+use GuzzleHttpLocal\Promise\EachPromise;
 
 /**
  * Sends and iterator of requests concurrently using a capped pool size.
@@ -50,7 +50,7 @@ class Pool implements PromisorInterface
             $opts = [];
         }
 
-        $iterable = \GuzzleHttp\Promise\iter_for($requests);
+        $iterable = \GuzzleHttpLocal\Promise\iter_for($requests);
         $requests = function () use ($iterable, $client, $opts) {
             foreach ($iterable as $key => $rfn) {
                 if ($rfn instanceof RequestInterface) {
@@ -85,7 +85,7 @@ class Pool implements PromisorInterface
      * @param ClientInterface $client   Client used to send the requests
      * @param array|\Iterator $requests Requests to send concurrently.
      * @param array           $options  Passes through the options available in
-     *                                  {@see GuzzleHttp\Pool::__construct}
+     *                                  {@see GuzzleHttpLocal\Pool::__construct}
      *
      * @return array Returns an array containing the response or an exception
      *               in the same order that the requests were sent.

--- a/vendor/guzzlehttp/guzzle/src/PrepareBodyMiddleware.php
+++ b/vendor/guzzlehttp/guzzle/src/PrepareBodyMiddleware.php
@@ -1,8 +1,8 @@
 <?php
-namespace GuzzleHttp;
+namespace GuzzleHttpLocal;
 
-use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7;
+use GuzzleHttpLocal\Promise\PromiseInterface;
+use GuzzleHttpLocal\Psr7;
 use Psr\Http\Message\RequestInterface;
 
 /**

--- a/vendor/guzzlehttp/guzzle/src/RedirectMiddleware.php
+++ b/vendor/guzzlehttp/guzzle/src/RedirectMiddleware.php
@@ -1,10 +1,10 @@
 <?php
-namespace GuzzleHttp;
+namespace GuzzleHttpLocal;
 
-use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Exception\TooManyRedirectsException;
-use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7;
+use GuzzleHttpLocal\Exception\BadResponseException;
+use GuzzleHttpLocal\Exception\TooManyRedirectsException;
+use GuzzleHttpLocal\Promise\PromiseInterface;
+use GuzzleHttpLocal\Psr7;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
@@ -13,7 +13,7 @@ use Psr\Http\Message\UriInterface;
  * Request redirect middleware.
  *
  * Apply this middleware like other middleware using
- * {@see GuzzleHttp\Middleware::redirect()}.
+ * {@see GuzzleHttpLocal\Middleware::redirect()}.
  */
 class RedirectMiddleware
 {

--- a/vendor/guzzlehttp/guzzle/src/RequestOptions.php
+++ b/vendor/guzzlehttp/guzzle/src/RequestOptions.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp;
+namespace GuzzleHttpLocal;
 
 /**
  * This class contains a list of built-in Guzzle request options.
@@ -58,11 +58,11 @@ final class RequestOptions
     const CERT = 'cert';
 
     /**
-     * cookies: (bool|GuzzleHttp\Cookie\CookieJarInterface, default=false)
+     * cookies: (bool|GuzzleHttpLocal\Cookie\CookieJarInterface, default=false)
      * Specifies whether or not cookies are used in a request or what cookie
      * jar to use or what cookies to send. This option only works if your
      * handler has the `cookie` middleware. Valid values are `false` and
-     * an instance of {@see GuzzleHttp\Cookie\CookieJarInterface}.
+     * an instance of {@see GuzzleHttpLocal\Cookie\CookieJarInterface}.
      */
     const COOKIES = 'cookies';
 

--- a/vendor/guzzlehttp/guzzle/src/RetryMiddleware.php
+++ b/vendor/guzzlehttp/guzzle/src/RetryMiddleware.php
@@ -1,9 +1,9 @@
 <?php
-namespace GuzzleHttp;
+namespace GuzzleHttpLocal;
 
-use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Promise\RejectedPromise;
-use GuzzleHttp\Psr7;
+use GuzzleHttpLocal\Promise\PromiseInterface;
+use GuzzleHttpLocal\Promise\RejectedPromise;
+use GuzzleHttpLocal\Psr7;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -97,7 +97,7 @@ class RetryMiddleware
                 null,
                 $reason
             )) {
-                return \GuzzleHttp\Promise\rejection_for($reason);
+                return \GuzzleHttpLocal\Promise\rejection_for($reason);
             }
             return $this->doRetry($req, $options);
         };

--- a/vendor/guzzlehttp/guzzle/src/TransferStats.php
+++ b/vendor/guzzlehttp/guzzle/src/TransferStats.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp;
+namespace GuzzleHttpLocal;
 
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;

--- a/vendor/guzzlehttp/guzzle/src/UriTemplate.php
+++ b/vendor/guzzlehttp/guzzle/src/UriTemplate.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp;
+namespace GuzzleHttpLocal;
 
 /**
  * Expands URI templates. Userland implementation of PECL uri_template.

--- a/vendor/guzzlehttp/guzzle/src/functions.php
+++ b/vendor/guzzlehttp/guzzle/src/functions.php
@@ -1,10 +1,10 @@
 <?php
-namespace GuzzleHttp;
+namespace GuzzleHttpLocal;
 
-use GuzzleHttp\Handler\CurlHandler;
-use GuzzleHttp\Handler\CurlMultiHandler;
-use GuzzleHttp\Handler\Proxy;
-use GuzzleHttp\Handler\StreamHandler;
+use GuzzleHttpLocal\Handler\CurlHandler;
+use GuzzleHttpLocal\Handler\CurlMultiHandler;
+use GuzzleHttpLocal\Handler\Proxy;
+use GuzzleHttpLocal\Handler\StreamHandler;
 
 /**
  * Expands a URI template
@@ -116,7 +116,7 @@ function choose_handler()
             ? Proxy::wrapStreaming($handler, new StreamHandler())
             : new StreamHandler();
     } elseif (!$handler) {
-        throw new \RuntimeException('GuzzleHttp requires cURL, the '
+        throw new \RuntimeException('GuzzleHttpLocal requires cURL, the '
             . 'allow_url_fopen ini setting, or a custom HTTP handler.');
     }
 
@@ -133,7 +133,7 @@ function default_user_agent()
     static $defaultAgent = '';
 
     if (!$defaultAgent) {
-        $defaultAgent = 'GuzzleHttp/' . Client::VERSION;
+        $defaultAgent = 'GuzzleHttpLocal/' . Client::VERSION;
         if (extension_loaded('curl') && function_exists('curl_version')) {
             $defaultAgent .= ' curl/' . \curl_version()['version'];
         }

--- a/vendor/guzzlehttp/guzzle/src/functions_include.php
+++ b/vendor/guzzlehttp/guzzle/src/functions_include.php
@@ -1,6 +1,6 @@
 <?php
 
 // Don't redefine the functions if included multiple times.
-if (!function_exists('GuzzleHttp\uri_template')) {
+if (!function_exists('GuzzleHttpLocal\uri_template')) {
     require __DIR__ . '/functions.php';
 }

--- a/vendor/guzzlehttp/promises/src/AggregateException.php
+++ b/vendor/guzzlehttp/promises/src/AggregateException.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Promise;
+namespace GuzzleHttpLocal\Promise;
 
 /**
  * Exception thrown when too many errors occur in the some() or any() methods.

--- a/vendor/guzzlehttp/promises/src/CancellationException.php
+++ b/vendor/guzzlehttp/promises/src/CancellationException.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Promise;
+namespace GuzzleHttpLocal\Promise;
 
 /**
  * Exception that is set as the reason for a promise that has been cancelled.

--- a/vendor/guzzlehttp/promises/src/Coroutine.php
+++ b/vendor/guzzlehttp/promises/src/Coroutine.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Promise;
+namespace GuzzleHttpLocal\Promise;
 
 use Exception;
 use Generator;
@@ -16,7 +16,7 @@ use Throwable;
  * This can lead to less verbose code when doing lots of sequential async calls
  * with minimal processing in between.
  *
- *     use GuzzleHttp\Promise;
+ *     use GuzzleHttpLocal\Promise;
  *
  *     function createPromise($value) {
  *         return new Promise\FulfilledPromise($value);

--- a/vendor/guzzlehttp/promises/src/EachPromise.php
+++ b/vendor/guzzlehttp/promises/src/EachPromise.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Promise;
+namespace GuzzleHttpLocal\Promise;
 
 /**
  * Represents a promise that iterates over many promises and invokes

--- a/vendor/guzzlehttp/promises/src/FulfilledPromise.php
+++ b/vendor/guzzlehttp/promises/src/FulfilledPromise.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Promise;
+namespace GuzzleHttpLocal\Promise;
 
 /**
  * A promise that has been fulfilled.

--- a/vendor/guzzlehttp/promises/src/Promise.php
+++ b/vendor/guzzlehttp/promises/src/Promise.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Promise;
+namespace GuzzleHttpLocal\Promise;
 
 /**
  * Promises/A+ implementation that avoids recursion when possible.

--- a/vendor/guzzlehttp/promises/src/PromiseInterface.php
+++ b/vendor/guzzlehttp/promises/src/PromiseInterface.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Promise;
+namespace GuzzleHttpLocal\Promise;
 
 /**
  * A promise represents the eventual result of an asynchronous operation.

--- a/vendor/guzzlehttp/promises/src/PromisorInterface.php
+++ b/vendor/guzzlehttp/promises/src/PromisorInterface.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Promise;
+namespace GuzzleHttpLocal\Promise;
 
 /**
  * Interface used with classes that return a promise.

--- a/vendor/guzzlehttp/promises/src/RejectedPromise.php
+++ b/vendor/guzzlehttp/promises/src/RejectedPromise.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Promise;
+namespace GuzzleHttpLocal\Promise;
 
 /**
  * A promise that has been rejected.

--- a/vendor/guzzlehttp/promises/src/RejectionException.php
+++ b/vendor/guzzlehttp/promises/src/RejectionException.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Promise;
+namespace GuzzleHttpLocal\Promise;
 
 /**
  * A special exception that is thrown when waiting on a rejected promise.

--- a/vendor/guzzlehttp/promises/src/TaskQueue.php
+++ b/vendor/guzzlehttp/promises/src/TaskQueue.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Promise;
+namespace GuzzleHttpLocal\Promise;
 
 /**
  * A task queue that executes tasks in a FIFO order.
@@ -8,7 +8,7 @@ namespace GuzzleHttp\Promise;
  * maintains a constant stack size. You can use the task queue asynchronously
  * by calling the `run()` function of the global task queue in an event loop.
  *
- *     GuzzleHttp\Promise\queue()->run();
+ *     GuzzleHttpLocal\Promise\queue()->run();
  */
 class TaskQueue implements TaskQueueInterface
 {

--- a/vendor/guzzlehttp/promises/src/TaskQueueInterface.php
+++ b/vendor/guzzlehttp/promises/src/TaskQueueInterface.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Promise;
+namespace GuzzleHttpLocal\Promise;
 
 interface TaskQueueInterface
 {

--- a/vendor/guzzlehttp/promises/src/functions.php
+++ b/vendor/guzzlehttp/promises/src/functions.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Promise;
+namespace GuzzleHttpLocal\Promise;
 
 /**
  * Get the global task queue used for promise resolution.
@@ -10,7 +10,7 @@ namespace GuzzleHttp\Promise;
  *
  * <code>
  * while ($eventLoop->isRunning()) {
- *     GuzzleHttp\Promise\queue()->run();
+ *     GuzzleHttpLocal\Promise\queue()->run();
  * }
  * </code>
  *
@@ -169,7 +169,7 @@ function inspect(PromiseInterface $promise)
  * @param PromiseInterface[] $promises Traversable of promises to wait upon.
  *
  * @return array
- * @see GuzzleHttp\Promise\inspect for the inspection state array format.
+ * @see GuzzleHttpLocal\Promise\inspect for the inspection state array format.
  */
 function inspect_all($promises)
 {
@@ -241,7 +241,7 @@ function all($promises)
  * fulfilled with an array that contains the fulfillment values of the winners
  * in order of resolution.
  *
- * This prommise is rejected with a {@see GuzzleHttp\Promise\AggregateException}
+ * This prommise is rejected with a {@see GuzzleHttpLocal\Promise\AggregateException}
  * if the number of fulfilled promises is less than the desired $count.
  *
  * @param int   $count    Total number of promises.
@@ -304,7 +304,7 @@ function any($promises)
  * @param mixed $promises Promises or values.
  *
  * @return PromiseInterface
- * @see GuzzleHttp\Promise\inspect for the inspection state array format.
+ * @see GuzzleHttpLocal\Promise\inspect for the inspection state array format.
  */
 function settle($promises)
 {

--- a/vendor/guzzlehttp/promises/src/functions_include.php
+++ b/vendor/guzzlehttp/promises/src/functions_include.php
@@ -1,6 +1,6 @@
 <?php
 
 // Don't redefine the functions if included multiple times.
-if (!function_exists('GuzzleHttp\Promise\promise_for')) {
+if (!function_exists('GuzzleHttpLocal\Promise\promise_for')) {
     require __DIR__ . '/functions.php';
 }

--- a/vendor/guzzlehttp/psr7/src/AppendStream.php
+++ b/vendor/guzzlehttp/psr7/src/AppendStream.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Psr7;
+namespace GuzzleHttpLocal\Psr7;
 
 use Psr\Http\Message\StreamInterface;
 

--- a/vendor/guzzlehttp/psr7/src/BufferStream.php
+++ b/vendor/guzzlehttp/psr7/src/BufferStream.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Psr7;
+namespace GuzzleHttpLocal\Psr7;
 
 use Psr\Http\Message\StreamInterface;
 

--- a/vendor/guzzlehttp/psr7/src/CachingStream.php
+++ b/vendor/guzzlehttp/psr7/src/CachingStream.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Psr7;
+namespace GuzzleHttpLocal\Psr7;
 
 use Psr\Http\Message\StreamInterface;
 

--- a/vendor/guzzlehttp/psr7/src/DroppingStream.php
+++ b/vendor/guzzlehttp/psr7/src/DroppingStream.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Psr7;
+namespace GuzzleHttpLocal\Psr7;
 
 use Psr\Http\Message\StreamInterface;
 

--- a/vendor/guzzlehttp/psr7/src/FnStream.php
+++ b/vendor/guzzlehttp/psr7/src/FnStream.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Psr7;
+namespace GuzzleHttpLocal\Psr7;
 
 use Psr\Http\Message\StreamInterface;
 

--- a/vendor/guzzlehttp/psr7/src/InflateStream.php
+++ b/vendor/guzzlehttp/psr7/src/InflateStream.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Psr7;
+namespace GuzzleHttpLocal\Psr7;
 
 use Psr\Http\Message\StreamInterface;
 

--- a/vendor/guzzlehttp/psr7/src/LazyOpenStream.php
+++ b/vendor/guzzlehttp/psr7/src/LazyOpenStream.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Psr7;
+namespace GuzzleHttpLocal\Psr7;
 
 use Psr\Http\Message\StreamInterface;
 

--- a/vendor/guzzlehttp/psr7/src/LimitStream.php
+++ b/vendor/guzzlehttp/psr7/src/LimitStream.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Psr7;
+namespace GuzzleHttpLocal\Psr7;
 
 use Psr\Http\Message\StreamInterface;
 

--- a/vendor/guzzlehttp/psr7/src/MessageTrait.php
+++ b/vendor/guzzlehttp/psr7/src/MessageTrait.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Psr7;
+namespace GuzzleHttpLocal\Psr7;
 
 use Psr\Http\Message\StreamInterface;
 

--- a/vendor/guzzlehttp/psr7/src/MultipartStream.php
+++ b/vendor/guzzlehttp/psr7/src/MultipartStream.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Psr7;
+namespace GuzzleHttpLocal\Psr7;
 
 use Psr\Http\Message\StreamInterface;
 

--- a/vendor/guzzlehttp/psr7/src/NoSeekStream.php
+++ b/vendor/guzzlehttp/psr7/src/NoSeekStream.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Psr7;
+namespace GuzzleHttpLocal\Psr7;
 
 use Psr\Http\Message\StreamInterface;
 

--- a/vendor/guzzlehttp/psr7/src/PumpStream.php
+++ b/vendor/guzzlehttp/psr7/src/PumpStream.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Psr7;
+namespace GuzzleHttpLocal\Psr7;
 
 use Psr\Http\Message\StreamInterface;
 

--- a/vendor/guzzlehttp/psr7/src/Request.php
+++ b/vendor/guzzlehttp/psr7/src/Request.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Psr7;
+namespace GuzzleHttpLocal\Psr7;
 
 use InvalidArgumentException;
 use Psr\Http\Message\RequestInterface;

--- a/vendor/guzzlehttp/psr7/src/Response.php
+++ b/vendor/guzzlehttp/psr7/src/Response.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Psr7;
+namespace GuzzleHttpLocal\Psr7;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;

--- a/vendor/guzzlehttp/psr7/src/ServerRequest.php
+++ b/vendor/guzzlehttp/psr7/src/ServerRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Psr7;
+namespace GuzzleHttpLocal\Psr7;
 
 use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;

--- a/vendor/guzzlehttp/psr7/src/Stream.php
+++ b/vendor/guzzlehttp/psr7/src/Stream.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Psr7;
+namespace GuzzleHttpLocal\Psr7;
 
 use Psr\Http\Message\StreamInterface;
 

--- a/vendor/guzzlehttp/psr7/src/StreamDecoratorTrait.php
+++ b/vendor/guzzlehttp/psr7/src/StreamDecoratorTrait.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Psr7;
+namespace GuzzleHttpLocal\Psr7;
 
 use Psr\Http\Message\StreamInterface;
 

--- a/vendor/guzzlehttp/psr7/src/StreamWrapper.php
+++ b/vendor/guzzlehttp/psr7/src/StreamWrapper.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Psr7;
+namespace GuzzleHttpLocal\Psr7;
 
 use Psr\Http\Message\StreamInterface;
 

--- a/vendor/guzzlehttp/psr7/src/UploadedFile.php
+++ b/vendor/guzzlehttp/psr7/src/UploadedFile.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Psr7;
+namespace GuzzleHttpLocal\Psr7;
 
 use InvalidArgumentException;
 use Psr\Http\Message\StreamInterface;

--- a/vendor/guzzlehttp/psr7/src/Uri.php
+++ b/vendor/guzzlehttp/psr7/src/Uri.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Psr7;
+namespace GuzzleHttpLocal\Psr7;
 
 use Psr\Http\Message\UriInterface;
 

--- a/vendor/guzzlehttp/psr7/src/UriNormalizer.php
+++ b/vendor/guzzlehttp/psr7/src/UriNormalizer.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Psr7;
+namespace GuzzleHttpLocal\Psr7;
 
 use Psr\Http\Message\UriInterface;
 
@@ -52,7 +52,7 @@ final class UriNormalizer
      * All of `file:/myfile`, `file:///myfile`, and `file://localhost/myfile`
      * are equivalent according to RFC 3986. The first format is not accepted
      * by PHPs stream functions and thus already normalized implicitly to the
-     * second format in the Uri class. See `GuzzleHttp\Psr7\Uri::composeComponents`.
+     * second format in the Uri class. See `GuzzleHttpLocal\Psr7\Uri::composeComponents`.
      *
      * Example: file://localhost/myfile → file:///myfile
      */

--- a/vendor/guzzlehttp/psr7/src/UriResolver.php
+++ b/vendor/guzzlehttp/psr7/src/UriResolver.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Psr7;
+namespace GuzzleHttpLocal\Psr7;
 
 use Psr\Http\Message\UriInterface;
 

--- a/vendor/guzzlehttp/psr7/src/functions.php
+++ b/vendor/guzzlehttp/psr7/src/functions.php
@@ -1,5 +1,5 @@
 <?php
-namespace GuzzleHttp\Psr7;
+namespace GuzzleHttpLocal\Psr7;
 
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;

--- a/vendor/guzzlehttp/psr7/src/functions_include.php
+++ b/vendor/guzzlehttp/psr7/src/functions_include.php
@@ -1,6 +1,6 @@
 <?php
 
 // Don't redefine the functions if included multiple times.
-if (!function_exists('GuzzleHttp\Psr7\str')) {
+if (!function_exists('GuzzleHttpLocal\Psr7\str')) {
     require __DIR__ . '/functions.php';
 }

--- a/vendor/microsoft/azure-storage/src/Blob/BlobRestProxy.php
+++ b/vendor/microsoft/azure-storage/src/Blob/BlobRestProxy.php
@@ -24,7 +24,7 @@
 
 namespace MicrosoftAzure\Storage\Blob;
 
-use GuzzleHttp\Psr7;
+use GuzzleHttpLocal\Psr7;
 use MicrosoftAzure\Storage\Blob\Internal\IBlob;
 use MicrosoftAzure\Storage\Blob\Models\AppendBlockOptions;
 use MicrosoftAzure\Storage\Blob\Models\AppendBlockResult;
@@ -282,7 +282,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string                    $operation The operation string. Should be
      * 'metadata' to get metadata.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     private function getContainerPropertiesAsyncImpl(
         $container,
@@ -470,7 +470,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param Models\BlobServiceOptions $options            Optional parameters.
      * @param Models\AccessCondition    $accessCondition    Access conditions.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     private function putLeaseAsyncImpl(
         $leaseAction,
@@ -562,7 +562,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string                 $content   The content string.
      * @param CreateBlobPagesOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     private function updatePageBlobPagesAsyncImpl(
         $action,
@@ -667,7 +667,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      *
      * @param  ListContainersOptions $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function listContainersAsync(
         ListContainersOptions $options = null
@@ -753,7 +753,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string                        $container The container name.
      * @param Models\CreateContainerOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179468.aspx
      */
@@ -819,7 +819,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param  string                             $container name of the container
      * @param  Models\BlobServiceOptions|null     $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function deleteContainerAsync(
         $container,
@@ -891,7 +891,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string                    $container name
      * @param Models\BlobServiceOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179370.aspx
      */
@@ -926,7 +926,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string                    $container name
      * @param Models\BlobServiceOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/ee691976.aspx
      */
@@ -962,7 +962,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string                    $container The container name.
      * @param Models\BlobServiceOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179469.aspx
      */
@@ -1068,7 +1068,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param Models\ContainerACL       $acl       access control list for container
      * @param Models\BlobServiceOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179391.aspx
      */
@@ -1161,7 +1161,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param array                    $metadata  metadata key/value pair.
      * @param Models\BlobServiceOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179362.aspx
      */
@@ -1240,7 +1240,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string                  $container The container name.
      * @param Models\ListBlobsOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd135734.aspx
      */
@@ -1378,7 +1378,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      *                                            boundary.
      * @param Models\CreateBlobOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179451.aspx
      */
@@ -1471,7 +1471,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string                   $blob      The blob name.
      * @param Models\CreateBlobOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179451.aspx
      */
@@ -1569,7 +1569,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string|resource|StreamInterface $content   The content of the blob.
      * @param Models\CreateBlobOptions        $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179451.aspx
      */
@@ -1647,7 +1647,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string|resource|StreamInterface $content   The content of the blob.
      * @param Models\CreateBlobOptions        $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/get-blob-properties
      */
@@ -1724,7 +1724,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param StreamInterface          $content   The content of the blob.
      * @param Models\CreateBlobOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179451.aspx
      */
@@ -1796,7 +1796,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param  Models\CreateBlobOptions $options    Array that contains
      *                                                     all the option
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     protected function createBlockBlobByMultipleUploadAsync(
         $container,
@@ -1915,7 +1915,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param  Models\CreateBlobOptions $options    Array that contains
      *                                                     all the option
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     private function uploadPageBlobAsync(
         $container,
@@ -2064,7 +2064,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      *                                                 512-1023)
      * @param Models\CreateBlobPagesOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/ee691975.aspx
      */
@@ -2128,7 +2128,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string|resource|StreamInterface $content   the blob contents.
      * @param Models\CreateBlobPagesOptions   $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/ee691975.aspx
      */
@@ -2212,7 +2212,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param resource|string|StreamInterface $content   the blob block contents
      * @param Models\CreateBlobBlockOptions   $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd135726.aspx
      */
@@ -2295,7 +2295,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param resource|string|StreamInterface $content   the blob block contents
      * @param Models\AppendBlockOptions       $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/append-block
      */
@@ -2497,7 +2497,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param Models\BlockList|Block[]       $blockList The block entries.
      * @param Models\CommitBlobBlocksOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179467.aspx
      */
@@ -2656,7 +2656,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string                       $blob      name of the blob
      * @param Models\ListBlobBlocksOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179400.aspx
      */
@@ -2750,7 +2750,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string                          $blob      name of the blob
      * @param Models\GetBlobPropertiesOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179394.aspx
      */
@@ -2830,7 +2830,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string                        $blob      name of the blob
      * @param Models\GetBlobMetadataOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179350.aspx
      */
@@ -2922,7 +2922,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string                           $blob      name of the blob
      * @param Models\ListPageBlobRangesOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/ee691973.aspx
      */
@@ -2987,7 +2987,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      *                                                                in `options`
      * @param Models\ListPageBlobRangesOptions $options               optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/ee691973.aspx
      */
@@ -3021,7 +3021,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      *                                                                in `options`
      * @param Models\ListPageBlobRangesOptions $options               optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/ee691973.aspx
      */
@@ -3137,7 +3137,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string                          $blob      name of the blob
      * @param Models\SetBlobPropertiesOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/ee691966.aspx
      */
@@ -3281,7 +3281,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param array                         $metadata  key/value pair representation
      * @param Models\BlobServiceOptions     $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179414.aspx
      */
@@ -3379,7 +3379,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string                $blob      name of the blob
      * @param Models\GetBlobOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179440.aspx
      */
@@ -3440,7 +3440,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string                $blob      name of the blob
      * @param Models\GetBlobOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179440.aspx
      */
@@ -3551,7 +3551,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string                   $blob      name of the blob
      * @param Models\DeleteBlobOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179413.aspx
      */
@@ -3644,7 +3644,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string                           $blob      The name of the blob.
      * @param Models\CreateBlobSnapshotOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/ee691971.aspx
      */
@@ -3745,7 +3745,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * blob
      * @param Models\CopyBlobOptions $options              optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd894037.aspx
      */
@@ -3822,7 +3822,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param Models\CopyBlobFromURLOptions $options              optional
      *                                                            parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd894037.aspx
      */
@@ -3935,7 +3935,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string                        $copyId               copy operation identifier.
      * @param Models\BlobServiceOptions     $options              optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/abort-copy-blob
      */
@@ -4057,7 +4057,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      *                                                      expire.
      * @param Models\BlobServiceOptions  $options           optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/ee691972.aspx
      */
@@ -4132,7 +4132,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string                    $proposedLeaseId   the proposed lease id
      * @param Models\BlobServiceOptions $options           optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/lease-blob
      */
@@ -4194,7 +4194,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string                    $leaseId   lease id when acquiring
      * @param Models\BlobServiceOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/lease-blob
      */
@@ -4252,7 +4252,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string                    $leaseId   lease id when acquiring
      * @param Models\BlobServiceOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/lease-blob
      */
@@ -4311,7 +4311,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      * @param string                    $blob      name of the blob
      * @param Models\BlobServiceOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/lease-blob
      */

--- a/vendor/microsoft/azure-storage/src/Blob/Internal/IBlob.php
+++ b/vendor/microsoft/azure-storage/src/Blob/Internal/IBlob.php
@@ -60,7 +60,7 @@ interface IBlob
      *
      * @param ServiceOptions $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/hh452239.aspx
      */
@@ -99,7 +99,7 @@ interface IBlob
      *
      * @param  ServiceOptions|null $options The options this operation sends with.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see  https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-stats
      */
@@ -114,7 +114,7 @@ interface IBlob
      * @param ServiceProperties           $serviceProperties new service properties.
      * @param ServiceOptions $options           optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/hh452235.aspx
      */
@@ -140,7 +140,7 @@ interface IBlob
      *
      * @param  BlobModels\ListContainersOptions $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function listContainersAsync(
         BlobModels\ListContainersOptions $options = null
@@ -167,7 +167,7 @@ interface IBlob
      * @param string                            $container The container name.
      * @param BlobModels\CreateContainerOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179468.aspx
      */
@@ -197,7 +197,7 @@ interface IBlob
      * @param  string                             $container name of the container
      * @param  BlobModels\BlobServiceOptions      $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function deleteContainerAsync(
         $container,
@@ -225,7 +225,7 @@ interface IBlob
      * @param string                        $container name
      * @param BlobModels\BlobServiceOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179370.aspx
      */
@@ -256,7 +256,7 @@ interface IBlob
      * @param string                        $container name
      * @param BlobModels\BlobServiceOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/ee691976.aspx
      */
@@ -288,7 +288,7 @@ interface IBlob
      * @param string                        $container The container name.
      * @param BlobModels\BlobServiceOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179469.aspx
      */
@@ -322,7 +322,7 @@ interface IBlob
      * @param BlobModels\ContainerACL       $acl       access control list for container
      * @param BlobModels\BlobServiceOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179391.aspx
      */
@@ -356,7 +356,7 @@ interface IBlob
      * @param array                         $metadata  metadata key/value pair.
      * @param BlobModels\BlobServiceOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179362.aspx
      */
@@ -387,7 +387,7 @@ interface IBlob
      * @param string                      $container The container name.
      * @param BlobModels\ListBlobsOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd135734.aspx
      */
@@ -433,7 +433,7 @@ interface IBlob
      *                                                512-byte boundary.
      * @param BlobModels\CreateBlobOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179451.aspx
      */
@@ -471,7 +471,7 @@ interface IBlob
      * @param string                   $blob      The blob name.
      * @param Models\CreateBlobOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179451.aspx
      */
@@ -519,7 +519,7 @@ interface IBlob
      * @param string|resource|StreamInterface $content   The content of the blob.
      * @param BlobModels\CreateBlobOptions    $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179451.aspx
      */
@@ -561,7 +561,7 @@ interface IBlob
      * @param string|resource|StreamInterface $content   The content of the blob.
      * @param BlobModels\CreateBlobOptions    $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/get-blob-properties
      */
@@ -605,7 +605,7 @@ interface IBlob
      *                                                     512-1023)
      * @param BlobModels\CreateBlobPagesOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/ee691975.aspx
      */
@@ -649,7 +649,7 @@ interface IBlob
      * @param string|resource|StreamInterface   $content   the blob contents.
      * @param BlobModels\CreateBlobPagesOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/ee691975.aspx
      */
@@ -701,7 +701,7 @@ interface IBlob
      * @param resource|string|StreamInterface     $content   the blob block contents
      * @param BlobModels\CreateBlobBlockOptions   $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd135726.aspx
      */
@@ -740,7 +740,7 @@ interface IBlob
      * @param resource|string|StreamInterface $content   the blob block contents
      * @param Models\AppendBlockOptions       $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/append-block
      */
@@ -795,7 +795,7 @@ interface IBlob
      *                                                           entries
      * @param BlobModels\CommitBlobBlocksOptions      $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179467.aspx
      */
@@ -847,7 +847,7 @@ interface IBlob
      * @param string                           $blob      name of the blob
      * @param BlobModels\ListBlobBlocksOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179400.aspx
      */
@@ -881,7 +881,7 @@ interface IBlob
      * @param string                              $blob      name of the blob
      * @param BlobModels\GetBlobPropertiesOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179394.aspx
      */
@@ -915,7 +915,7 @@ interface IBlob
      * @param string                            $blob      name of the blob
      * @param BlobModels\GetBlobMetadataOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179350.aspx
      */
@@ -952,7 +952,7 @@ interface IBlob
      * @param string                               $blob      name of the blob
      * @param BlobModels\ListPageBlobRangesOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/ee691973.aspx
      */
@@ -1008,7 +1008,7 @@ interface IBlob
      *                                                                      in `options`
      * @param BlobModels\ListPageBlobRangesOptions $options                 optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/ee691973.aspx
      */
@@ -1043,7 +1043,7 @@ interface IBlob
      * @param string                              $blob      name of the blob
      * @param BlobModels\SetBlobPropertiesOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/ee691966.aspx
      */
@@ -1080,7 +1080,7 @@ interface IBlob
      * @param array                             $metadata  key/value pair representation
      * @param BlobModels\BlobServiceOptions     $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179414.aspx
      */
@@ -1117,7 +1117,7 @@ interface IBlob
      * @param string                    $blob      name of the blob
      * @param BlobModels\GetBlobOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179440.aspx
      */
@@ -1159,7 +1159,7 @@ interface IBlob
      * @param string                       $blob      name of the blob
      * @param BlobModels\DeleteBlobOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179413.aspx
      */
@@ -1196,7 +1196,7 @@ interface IBlob
      * @param BlobModels\CreateBlobSnapshotOptions $options   The optional
      *                                                        parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/ee691971.aspx
      */
@@ -1242,7 +1242,7 @@ interface IBlob
      *                                                         blob
      * @param BlobModels\CopyBlobOptions $options              optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd894037.aspx
      */
@@ -1295,7 +1295,7 @@ interface IBlob
      * @param BlobModels\CopyBlobFromURLOptions $options              optional
      *                                                                parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd894037.aspx
      */
@@ -1333,7 +1333,7 @@ interface IBlob
      * @param string                        $copyId               copy operation identifier.
      * @param BlobModels\BlobServiceOptions $options              optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/abort-copy-blob
      */
@@ -1380,7 +1380,7 @@ interface IBlob
      *                                                      Default is never to expire.
      * @param Models\BlobServiceOptions  $options           optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/ee691972.aspx
      */
@@ -1422,7 +1422,7 @@ interface IBlob
      * @param string                        $proposedLeaseId   the proposed lease id
      * @param BlobModels\BlobServiceOptions $options           optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/lease-blob
      */
@@ -1461,7 +1461,7 @@ interface IBlob
      * @param string                        $leaseId   lease id when acquiring
      * @param BlobModels\BlobServiceOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/ee691972.aspx
      */
@@ -1502,7 +1502,7 @@ interface IBlob
      * @param string                        $leaseId   lease id when acquiring
      * @param BlobModels\BlobServiceOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/ee691972.aspx
      */
@@ -1540,7 +1540,7 @@ interface IBlob
      * @param string                        $blob      name of the blob
      * @param BlobModels\BlobServiceOptions $options   optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/ee691972.aspx
      */

--- a/vendor/microsoft/azure-storage/src/Common/Internal/Authentication/IAuthScheme.php
+++ b/vendor/microsoft/azure-storage/src/Common/Internal/Authentication/IAuthScheme.php
@@ -24,7 +24,7 @@
 
 namespace MicrosoftAzure\Storage\Common\Internal\Authentication;
 
-use GuzzleHttp\Psr7\Request;
+use GuzzleHttpLocal\Psr7\Request;
 
 /**
  * Interface for azure authentication schemes.
@@ -42,11 +42,11 @@ interface IAuthScheme
     /**
      * Signs a request.
      *
-     * @param  \GuzzleHttp\Psr7\Request $request HTTP request object.
+     * @param  \GuzzleHttpLocal\Psr7\Request $request HTTP request object.
      *
      * @abstract
      *
-     * @return \GuzzleHttp\Psr7\Request
+     * @return \GuzzleHttpLocal\Psr7\Request
      */
     public function signRequest(Request $request);
 }

--- a/vendor/microsoft/azure-storage/src/Common/Internal/Authentication/SharedAccessSignatureAuthScheme.php
+++ b/vendor/microsoft/azure-storage/src/Common/Internal/Authentication/SharedAccessSignatureAuthScheme.php
@@ -24,7 +24,7 @@
 
 namespace MicrosoftAzure\Storage\Common\Internal\Authentication;
 
-use GuzzleHttp\Psr7\Request;
+use GuzzleHttpLocal\Psr7\Request;
 
 /**
  * Base class for azure authentication schemes.
@@ -60,11 +60,11 @@ class SharedAccessSignatureAuthScheme implements IAuthScheme
     /**
      * Adds authentication header to the request headers.
      *
-     * @param  \GuzzleHttp\Psr7\Request $request HTTP request object.
+     * @param  \GuzzleHttpLocal\Psr7\Request $request HTTP request object.
      *
      * @abstract
      *
-     * @return \GuzzleHttp\Psr7\Request
+     * @return \GuzzleHttpLocal\Psr7\Request
      */
     public function signRequest(Request $request)
     {
@@ -78,7 +78,7 @@ class SharedAccessSignatureAuthScheme implements IAuthScheme
         foreach ($queryValues as $queryField) {
             list($key, $value) = explode('=', $queryField);
 
-            $uri = \GuzzleHttp\Psr7\Uri::withQueryValue($uri, $key, $value);
+            $uri = \GuzzleHttpLocal\Psr7\Uri::withQueryValue($uri, $key, $value);
         }
 
         // replace URI

--- a/vendor/microsoft/azure-storage/src/Common/Internal/Authentication/SharedKeyAuthScheme.php
+++ b/vendor/microsoft/azure-storage/src/Common/Internal/Authentication/SharedKeyAuthScheme.php
@@ -24,7 +24,7 @@
 
 namespace MicrosoftAzure\Storage\Common\Internal\Authentication;
 
-use GuzzleHttp\Psr7\Request;
+use GuzzleHttpLocal\Psr7\Request;
 use MicrosoftAzure\Storage\Common\Internal\Http\HttpFormatter;
 use MicrosoftAzure\Storage\Common\Internal\Resources;
 use MicrosoftAzure\Storage\Common\Internal\Utilities;
@@ -292,11 +292,11 @@ class SharedKeyAuthScheme implements IAuthScheme
     /**
      * Adds authentication header to the request headers.
      *
-     * @param  \GuzzleHttp\Psr7\Request $request HTTP request object.
+     * @param  \GuzzleHttpLocal\Psr7\Request $request HTTP request object.
      *
      * @abstract
      *
-     * @return \GuzzleHttp\Psr7\Request
+     * @return \GuzzleHttpLocal\Psr7\Request
      */
     public function signRequest(Request $request)
     {
@@ -305,7 +305,7 @@ class SharedKeyAuthScheme implements IAuthScheme
         $signedKey = $this->getAuthorizationHeader(
             $requestHeaders,
             $request->getUri(),
-            \GuzzleHttp\Psr7\parse_query(
+            \GuzzleHttpLocal\Psr7\parse_query(
                 $request->getUri()->getQuery()
             ),
             $request->getMethod()

--- a/vendor/microsoft/azure-storage/src/Common/Internal/Serialization/MessageSerializer.php
+++ b/vendor/microsoft/azure-storage/src/Common/Internal/Serialization/MessageSerializer.php
@@ -26,7 +26,7 @@ namespace MicrosoftAzure\Storage\Common\Internal\Serialization;
 
 use MicrosoftAzure\Storage\Common\Internal\Validate;
 use MicrosoftAzure\Storage\Common\Internal\Resources;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttpLocal\Exception\RequestException;
 
 /**
  * Provides functionality to serialize a message to a string.

--- a/vendor/microsoft/azure-storage/src/Common/Internal/ServiceRestProxy.php
+++ b/vendor/microsoft/azure-storage/src/Common/Internal/ServiceRestProxy.php
@@ -31,12 +31,12 @@ use MicrosoftAzure\Storage\Common\Internal\Http\HttpCallContext;
 use MicrosoftAzure\Storage\Common\Internal\Middlewares\MiddlewareBase;
 use MicrosoftAzure\Storage\Common\Middlewares\MiddlewareStack;
 use MicrosoftAzure\Storage\Common\LocationMode;
-use GuzzleHttp\Promise\EachPromise;
-use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Psr7\Uri;
-use GuzzleHttp\Client;
-use GuzzleHttp\Psr7;
+use GuzzleHttpLocal\Promise\EachPromise;
+use GuzzleHttpLocal\Exception\RequestException;
+use GuzzleHttpLocal\Psr7\Request;
+use GuzzleHttpLocal\Psr7\Uri;
+use GuzzleHttpLocal\Client;
+use GuzzleHttpLocal\Psr7;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -108,7 +108,7 @@ class ServiceRestProxy extends RestProxy
             $options['proxy'] = $proxy;
         }
 
-        return (new \GuzzleHttp\Client(
+        return (new \GuzzleHttpLocal\Client(
             array_merge(
                 $options,
                 array(
@@ -254,7 +254,7 @@ class ServiceRestProxy extends RestProxy
      * @param  string $path           URL path
      * @param  string $body           Request body
      *
-     * @return \GuzzleHttp\Psr7\Request
+     * @return \GuzzleHttpLocal\Psr7\Request
      */
     protected function createRequest(
         $method,
@@ -330,7 +330,7 @@ class ServiceRestProxy extends RestProxy
      * @param  string         $body           Request body
      * @param  ServiceOptions $serviceOptions Service options
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     protected function sendAsync(
         $method,
@@ -440,7 +440,7 @@ class ServiceRestProxy extends RestProxy
      * Sends the context.
      *
      * @param  HttpCallContext $context The context of the request.
-     * @return \GuzzleHttp\Psr7\Response
+     * @return \GuzzleHttpLocal\Psr7\Response
      */
     protected function sendContext(HttpCallContext $context)
     {
@@ -452,7 +452,7 @@ class ServiceRestProxy extends RestProxy
      *
      * @param  HttpCallContext $context The context of the request.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     protected function sendContextAsync(HttpCallContext $context)
     {

--- a/vendor/microsoft/azure-storage/src/Common/Internal/ServiceRestTrait.php
+++ b/vendor/microsoft/azure-storage/src/Common/Internal/ServiceRestTrait.php
@@ -66,7 +66,7 @@ trait ServiceRestTrait
      *
      * @param ServiceOptions $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/hh452239.aspx
      */
@@ -140,7 +140,7 @@ trait ServiceRestTrait
      * @param ServiceProperties $serviceProperties The service properties.
      * @param ServiceOptions    $options           The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/hh452235.aspx
      */
@@ -213,7 +213,7 @@ trait ServiceRestTrait
      *
      * @param  ServiceOptions|null $options The options this operation sends with.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function getServiceStatsAsync(ServiceOptions $options = null)
     {

--- a/vendor/microsoft/azure-storage/src/Common/Internal/Utilities.php
+++ b/vendor/microsoft/azure-storage/src/Common/Internal/Utilities.php
@@ -25,7 +25,7 @@
 
 namespace MicrosoftAzure\Storage\Common\Internal;
 
-use GuzzleHttp\Psr7\Stream;
+use GuzzleHttpLocal\Psr7\Stream;
 
 /**
  * Utilities for the project

--- a/vendor/microsoft/azure-storage/src/Common/Middlewares/HistoryMiddleware.php
+++ b/vendor/microsoft/azure-storage/src/Common/Middlewares/HistoryMiddleware.php
@@ -29,7 +29,7 @@ use MicrosoftAzure\Storage\Common\Internal\Utilities;
 use MicrosoftAzure\Storage\Common\Internal\Serialization\MessageSerializer;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use GuzzleHttp\Promise\RejectedPromise;
+use GuzzleHttpLocal\Promise\RejectedPromise;
 
 /**
  * This class provides the functionality to log the requests/options/responses.

--- a/vendor/microsoft/azure-storage/src/Common/Middlewares/IMiddleware.php
+++ b/vendor/microsoft/azure-storage/src/Common/Middlewares/IMiddleware.php
@@ -58,7 +58,7 @@ interface IMiddleware
      *        },
      *        function ($reason) use ($request, $options) {
      *            //do something
-     *            return new GuzzleHttp\Promise\RejectedPromise($reason);
+     *            return new GuzzleHttpLocal\Promise\RejectedPromise($reason);
      *        }
      *    );
      * };

--- a/vendor/microsoft/azure-storage/src/Common/Middlewares/MiddlewareBase.php
+++ b/vendor/microsoft/azure-storage/src/Common/Middlewares/MiddlewareBase.php
@@ -26,7 +26,7 @@ namespace MicrosoftAzure\Storage\Common\Middlewares;
 
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use GuzzleHttp\Promise\RejectedPromise;
+use GuzzleHttpLocal\Promise\RejectedPromise;
 
 /**
  * This class provides the base structure of middleware that can be used for

--- a/vendor/microsoft/azure-storage/src/Common/Middlewares/RetryMiddleware.php
+++ b/vendor/microsoft/azure-storage/src/Common/Middlewares/RetryMiddleware.php
@@ -29,8 +29,8 @@ use MicrosoftAzure\Storage\Common\Internal\Resources;
 use MicrosoftAzure\Storage\Common\Internal\Utilities;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use GuzzleHttp\Psr7\Uri;
-use GuzzleHttp\Promise\RejectedPromise;
+use GuzzleHttpLocal\Psr7\Uri;
+use GuzzleHttpLocal\Promise\RejectedPromise;
 
 /**
  * This class provides the functionality of a middleware that handles all the

--- a/vendor/microsoft/azure-storage/src/Common/Middlewares/RetryMiddlewareFactory.php
+++ b/vendor/microsoft/azure-storage/src/Common/Middlewares/RetryMiddlewareFactory.php
@@ -26,7 +26,7 @@ namespace MicrosoftAzure\Storage\Common\Middlewares;
 
 use MicrosoftAzure\Storage\Common\Internal\Resources;
 use MicrosoftAzure\Storage\Common\Internal\Validate;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttpLocal\Exception\RequestException;
 
 /**
  * This class provides static functions that creates retry handlers for Guzzle

--- a/vendor/microsoft/azure-storage/src/File/FileRestProxy.php
+++ b/vendor/microsoft/azure-storage/src/File/FileRestProxy.php
@@ -55,7 +55,7 @@ use MicrosoftAzure\Storage\File\Models\ListFileRangesResult;
 use MicrosoftAzure\Storage\File\Models\CopyFileResult;
 use MicrosoftAzure\Storage\Common\Internal\Http\HttpFormatter;
 use Psr\Http\Message\StreamInterface;
-use GuzzleHttp\Psr7;
+use GuzzleHttpLocal\Psr7;
 
 /**
  * This class constructs HTTP requests and receive HTTP responses for File
@@ -115,7 +115,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      *                                      and 'properties' to set
      *                                      properties.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     private function getSharePropertiesAsyncImpl(
         $share,
@@ -186,7 +186,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      *                                       and 'properties' to set
      *                                       properties.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     private function setSharePropertiesAsyncImpl(
         $share,
@@ -258,7 +258,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      *                                           4MB length min.
      * @param  PutFileRangeOptions|null $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/put-range
      *
@@ -378,7 +378,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      *
      * @param  ListSharesOptions|null $options The optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/list-shares
      */
@@ -470,7 +470,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      * @param string                  $share   The share name.
      * @param CreateShareOptions|null $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-share
      */
@@ -540,7 +540,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      * @param string                  $share   name of the share
      * @param FileServiceOptions|null $options optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-share
      */
@@ -608,7 +608,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      * @param string                  $share   name
      * @param FileServiceOptions|null $options optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-properties
      */
@@ -645,7 +645,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      * @param int                     $quota   quota of the share
      * @param FileServiceOptions|null $options optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-share-properties
      */
@@ -686,7 +686,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      * @param string                  $share   name
      * @param FileServiceOptions|null $options optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-metadata
      */
@@ -723,7 +723,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      * @param array                   $metadata metadata key/value pair.
      * @param FileServiceOptions|null $options optional  parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-share-metadata
      */
@@ -763,7 +763,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      * @param string                  $share The share name.
      * @param FileServiceOptions|null $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-acl
      */
@@ -859,7 +859,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      * @param ShareACL                $acl     access control list for share
      * @param FileServiceOptions|null $options optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-share-acl
      */
@@ -936,7 +936,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      * @param  string                  $share   The name of the share.
      * @param  FileServiceOptions|null $options The request options.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-stats
      */
@@ -1019,7 +1019,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      * @param  string                              $path    The path to be listed.
      * @param  ListDirectoriesAndFilesOptions|null $options Optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/list-directories-and-files
      */
@@ -1120,7 +1120,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      * @param string                      $path      The path to create the directory.
      * @param CreateDirectoryOptions|null $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-directory
      */
@@ -1190,7 +1190,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      * @param string                  $path      The path to delete the directory.
      * @param FileServiceOptions|null $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-directory
      */
@@ -1257,7 +1257,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      * @param string                  $path      The path of the directory.
      * @param FileServiceOptions|null $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-directory-properties
      */
@@ -1327,7 +1327,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      * @param string                  $path      The path of the directory.
      * @param FileServiceOptions|null $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-directory-metadata
      */
@@ -1411,7 +1411,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      * @param array                   $metadata  The metadata to be set.
      * @param FileServiceOptions|null $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-directory-metadata
      */
@@ -1493,7 +1493,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      * @param int                    $size    The size of the file.
      * @param CreateFileOptions|null $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-file
      */
@@ -1620,7 +1620,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      * @param string                  $path      The path to delete the file.
      * @param FileServiceOptions|null $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2
      */
@@ -1688,7 +1688,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      * @param string              $path    path of the file to be get
      * @param GetFileOptions|null $options optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-file
      */
@@ -1778,7 +1778,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      * @param string                  $path      The path to delete the file.
      * @param FileServiceOptions|null $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-file-properties
      */
@@ -1850,7 +1850,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      * @param FileProperties          $properties file properties.
      * @param FileServiceOptions|null $options    optional     parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-file-properties
      */
@@ -1961,7 +1961,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      * @param string                  $path      The path of the file.
      * @param FileServiceOptions|null $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-file-metadata
      */
@@ -2045,7 +2045,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      * @param array                   $metadata  The metadata to be set.
      * @param FileServiceOptions|null $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-file-metadata
      */
@@ -2134,7 +2134,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      *                                                  be put.
      * @param  PutFileRangeOptions|null        $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/put-range
      *
@@ -2333,7 +2333,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      *                                          be cleared.
      * @param  FileServiceOptions|null $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/put-range
      *
@@ -2426,7 +2426,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      *                                          be listed.
      * @param  FileServiceOptions|null $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/list-ranges
      *
@@ -2553,7 +2553,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
      *                                             will not be copied.
      * @param  FileServiceOptions|null $options    The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/copy-file
      *

--- a/vendor/microsoft/azure-storage/src/File/Internal/IFile.php
+++ b/vendor/microsoft/azure-storage/src/File/Internal/IFile.php
@@ -59,7 +59,7 @@ interface IFile
      *
      * @param ServiceOptions $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-file-service-properties
      */
@@ -89,7 +89,7 @@ interface IFile
      * @param ServiceProperties $serviceProperties new service properties.
      * @param ServiceOptions    $options           optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-file-service-properties
      */
@@ -114,7 +114,7 @@ interface IFile
      *
      * @param  FileModels\ListSharesOptions|null $options The optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/list-shares
      */
@@ -141,7 +141,7 @@ interface IFile
      * @param string                             $share   The share name.
      * @param FileModels\CreateShareOptions|null $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-share
      */
@@ -171,7 +171,7 @@ interface IFile
      * @param  string                             $share   name of the share
      * @param  FileModels\FileServiceOptions|null $options optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-share
      */
@@ -201,7 +201,7 @@ interface IFile
      * @param string                             $share   name
      * @param FileModels\FileServiceOptions|null $options optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-properties
      */
@@ -234,7 +234,7 @@ interface IFile
      * @param int                                $quota   quota of the share
      * @param FileModels\FileServiceOptions|null $options optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-share-properties
      */
@@ -266,7 +266,7 @@ interface IFile
     * @param string                             $share   name
     * @param FileModels\FileServiceOptions|null $options optional parameters
     *
-    * @return \GuzzleHttp\Promise\PromiseInterface
+    * @return \GuzzleHttpLocal\Promise\PromiseInterface
     *
     * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-metadata
     */
@@ -299,7 +299,7 @@ interface IFile
      * @param array                              $metadata metadata key/value pair.
      * @param FileModels\FileServiceOptions|null $options optional  parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-share-metadata
      */
@@ -330,7 +330,7 @@ interface IFile
      * @param string                             $share   The share name.
      * @param FileModels\FileServiceOptions|null $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-acl
      */
@@ -366,7 +366,7 @@ interface IFile
      * for share
      * @param FileModels\FileServiceOptions|null $options optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-share-acl
      */
@@ -397,7 +397,7 @@ interface IFile
      * @param  string                             $share   The name of the share.
      * @param  FileModels\FileServiceOptions|null $options The request options.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-stats
      */
@@ -434,7 +434,7 @@ interface IFile
      * @param  string                              $path    The path to be listed.
      * @param  FileModels\ListDirectoriesAndFilesOptions|null $options Optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/list-directories-and-files
      */
@@ -470,7 +470,7 @@ interface IFile
      *                                                          create the directory.
      * @param FileModels\CreateDirectoryOptions|null $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-directory
      */
@@ -506,7 +506,7 @@ interface IFile
      *                                                      the directory.
      * @param FileModels\FileServiceOptions|null $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-directory
      */
@@ -541,7 +541,7 @@ interface IFile
      * @param string                            $path      The path of the directory.
      * @param FileModelsFileServiceOptions|null $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-directory-properties
      */
@@ -576,7 +576,7 @@ interface IFile
      * @param string                             $path      The path of the directory.
      * @param FileModels\FileServiceOptions|null $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-directory-metadata
      */
@@ -616,7 +616,7 @@ interface IFile
      * @param array                              $metadata  The metadata to be set.
      * @param FileModels\FileServiceOptions|null $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-directory-metadata
      */
@@ -654,7 +654,7 @@ interface IFile
      * @param int                               $size    The size of the file.
      * @param FileModels\CreateFileOptions|null $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-file
      */
@@ -689,7 +689,7 @@ interface IFile
      * @param string                             $path      The path to delete the file.
      * @param FileModels\FileServiceOptions|null $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2
      */
@@ -725,7 +725,7 @@ interface IFile
      * @param string                         $path    path of the file to be get
      * @param FileModels\GetFileOptions|null $options optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-file
      */
@@ -760,7 +760,7 @@ interface IFile
      * @param string                             $path      The path to delete the file.
      * @param FileModels\FileServiceOptions|null $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-file-properties
      */
@@ -797,7 +797,7 @@ interface IFile
      * @param FileModels\FileProperties          $properties file properties.
      * @param FileModels\FileServiceOptions|null $options    optional     parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-file-properties
      */
@@ -833,7 +833,7 @@ interface IFile
      * @param string                             $path      The path of the file.
      * @param FileModels\FileServiceOptions|null $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-file-metadata
      */
@@ -871,7 +871,7 @@ interface IFile
      * @param array                              $metadata  The metadata to be set.
      * @param FileModels\FileServiceOptions|null $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-file-metadata
      */
@@ -915,7 +915,7 @@ interface IFile
      *                                                      be put.
      * @param  FileModels\PutFileRangeOptions|null $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/put-range
      *
@@ -999,7 +999,7 @@ interface IFile
      *                                                     be cleared.
      * @param  FileModels\FileServiceOptions|null $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/put-range
      *
@@ -1040,7 +1040,7 @@ interface IFile
      *                                                     be listed.
      * @param  FileModels\FileServiceOptions|null $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/list-ranges
      *
@@ -1111,7 +1111,7 @@ interface IFile
      *                                                        be copied.
      * @param  FileModels\FileServiceOptions|null $options    The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/copy-file
      *

--- a/vendor/microsoft/azure-storage/src/Queue/Internal/IQueue.php
+++ b/vendor/microsoft/azure-storage/src/Queue/Internal/IQueue.php
@@ -59,7 +59,7 @@ interface IQueue
      *
      * @param ServiceOptions $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function getServicePropertiesAsync(
         ServiceOptions $options = null
@@ -90,7 +90,7 @@ interface IQueue
      * @param ServiceProperties $serviceProperties The new service properties.
      * @param ServiceOptions    $options           The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function setServicePropertiesAsync(
         ServiceProperties $serviceProperties,
@@ -115,7 +115,7 @@ interface IQueue
      *
      * @param  ServiceOptions|null $options The options this operation sends with.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see  https://docs.microsoft.com/en-us/rest/api/storageservices/get-queue-service-stats
      */
@@ -140,7 +140,7 @@ interface IQueue
      * @param string                     $queueName The queue name.
      * @param QueueModels\CreateQueueOptions  $options   The Optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function createQueueAsync(
         $queueName,
@@ -166,7 +166,7 @@ interface IQueue
      * @param string                          $queueName The queue name.
      * @param QueueModels\QueueServiceOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function deleteQueueAsync(
         $queueName,
@@ -187,7 +187,7 @@ interface IQueue
      *
      * @param QueueModels\ListQueuesOptions $options The optional list queue options.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function listQueuesAsync(QueueModels\ListQueuesOptions $options = null);
 
@@ -210,7 +210,7 @@ interface IQueue
      * @param string                          $queueName The queue name.
      * @param QueueModels\QueueServiceOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function getQueueMetadataAsync(
         $queueName,
@@ -241,7 +241,7 @@ interface IQueue
      * @param array                           $metadata  The metadata array.
      * @param QueueModels\QueueServiceOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function setQueueMetadataAsync(
         $queueName,
@@ -274,7 +274,7 @@ interface IQueue
      * @param QueueModels\CreateMessageOptions $options     The optional
      *                                                      parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function createMessageAsync(
         $queueName,
@@ -329,7 +329,7 @@ interface IQueue
      * @param QueueModels\QueueServiceOptions $options        The optional
      * parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function updateMessageAsync(
         $queueName,
@@ -373,7 +373,7 @@ interface IQueue
      *                                                    update Message operation.
      * @param QueueModels\QueueServiceOptions $options    The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function deleteMessageAsync(
         $queueName,
@@ -401,7 +401,7 @@ interface IQueue
      * @param string              $queueName The queue name.
      * @param QueueModels\ListMessagesOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function listMessagesAsync(
         $queueName,
@@ -429,7 +429,7 @@ interface IQueue
      * @param string                          $queueName The queue name.
      * @param QueueModels\PeekMessagesOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function peekMessagesAsync(
         $queueName,
@@ -462,7 +462,7 @@ interface IQueue
      * @param string                          $queueName The name of the queue.
      * @param QueueModels\QueueServiceOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function clearMessagesAsync(
         $queueName,
@@ -490,7 +490,7 @@ interface IQueue
      * @param string                          $queue   The queue name.
      * @param QueueModels\QueueServiceOptions $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/get-queue-acl
      */
@@ -523,7 +523,7 @@ interface IQueue
      * @param QueueModels\QueueACL            $acl     access control list
      * @param QueueModels\QueueServiceOptions $options optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/set-queue-acl
      */

--- a/vendor/microsoft/azure-storage/src/Queue/QueueRestProxy.php
+++ b/vendor/microsoft/azure-storage/src/Queue/QueueRestProxy.php
@@ -79,7 +79,7 @@ class QueueRestProxy extends ServiceRestProxy implements IQueue
      *
      * @param ListQueuesOptions $options The optional list queue options.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function listQueuesAsync(ListQueuesOptions $options = null)
     {
@@ -162,7 +162,7 @@ class QueueRestProxy extends ServiceRestProxy implements IQueue
      * @param string              $queueName The name of the queue.
      * @param QueueServiceOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function clearMessagesAsync(
         $queueName,
@@ -222,7 +222,7 @@ class QueueRestProxy extends ServiceRestProxy implements IQueue
      * @param string               $messageText The message contents.
      * @param CreateMessageOptions $options     The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function createMessageAsync(
         $queueName,
@@ -308,7 +308,7 @@ class QueueRestProxy extends ServiceRestProxy implements IQueue
      * @param string                     $queueName The queue name.
      * @param Models\CreateQueueOptions  $options   The Optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function createQueueAsync(
         $queueName,
@@ -378,7 +378,7 @@ class QueueRestProxy extends ServiceRestProxy implements IQueue
      * from an earlier call to the Get Messages or Update Message operation.
      * @param QueueServiceOptions $options    The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function deleteMessageAsync(
         $queueName,
@@ -443,7 +443,7 @@ class QueueRestProxy extends ServiceRestProxy implements IQueue
      * @param string              $queueName The queue name.
      * @param QueueServiceOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function deleteQueueAsync(
         $queueName,
@@ -495,7 +495,7 @@ class QueueRestProxy extends ServiceRestProxy implements IQueue
      * @param string              $queueName The queue name.
      * @param QueueServiceOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function getQueueMetadataAsync(
         $queueName,
@@ -559,7 +559,7 @@ class QueueRestProxy extends ServiceRestProxy implements IQueue
      * @param string              $queueName The queue name.
      * @param ListMessagesOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function listMessagesAsync(
         $queueName,
@@ -632,7 +632,7 @@ class QueueRestProxy extends ServiceRestProxy implements IQueue
      * @param string              $queueName The queue name.
      * @param PeekMessagesOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function peekMessagesAsync(
         $queueName,
@@ -703,7 +703,7 @@ class QueueRestProxy extends ServiceRestProxy implements IQueue
      * @param array               $metadata  The metadata array.
      * @param QueueServiceOptions $options   The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function setQueueMetadataAsync(
         $queueName,
@@ -801,7 +801,7 @@ class QueueRestProxy extends ServiceRestProxy implements IQueue
      * @param QueueServiceOptions $options                    The optional
      * parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function updateMessageAsync(
         $queueName,
@@ -901,7 +901,7 @@ class QueueRestProxy extends ServiceRestProxy implements IQueue
      * @param string                     $queue   The queue name.
      * @param Models\QueueServiceOptions $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/get-queue-acl
      */
@@ -973,7 +973,7 @@ class QueueRestProxy extends ServiceRestProxy implements IQueue
      * @param Models\QueueACL            $acl     access control list for Queue
      * @param Models\QueueServiceOptions $options optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/set-queue-acl
      */

--- a/vendor/microsoft/azure-storage/src/Table/Internal/ITable.php
+++ b/vendor/microsoft/azure-storage/src/Table/Internal/ITable.php
@@ -61,7 +61,7 @@ interface ITable
      *
      * @param ServiceOptions $options optional table service options.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/hh452238.aspx
      */
@@ -93,7 +93,7 @@ interface ITable
      * @param ServiceProperties $serviceProperties new service properties
      * @param ServiceOptions    $options           optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/hh452240.aspx
      */
@@ -120,7 +120,7 @@ interface ITable
      *
      * @param  ServiceOptions|null $options The options this operation sends with.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-table-service-stats
      */
@@ -144,7 +144,7 @@ interface ITable
      * @param TableModels\QueryTablesOptions|string|Models\Filters\Filter $options
      * Could be optional parameters, table prefix or filter to apply.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/query-tables
      */
@@ -171,7 +171,7 @@ interface ITable
      * @param string                                $table   The name of the table.
      * @param TableModels\TableServiceCreateOptions $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-table
      */
@@ -199,7 +199,7 @@ interface ITable
      * @param string                      $table   The name of the table.
      * @param TableModels\GetTableOptions $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function getTableAsync(
         $table,
@@ -227,7 +227,7 @@ interface ITable
      * @param string                          $table   The name of the table.
      * @param TableModels\TableServiceOptions $options optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179387.aspx
      */
@@ -258,7 +258,7 @@ interface ITable
      * @param Models\QueryEntitiesOptions|string|Models\Filters\Filter $options Coule be
      * optional parameters, query string or filter to apply.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/query-entities
      */
@@ -288,7 +288,7 @@ interface ITable
      * @param TableModels\Entity                    $entity  table entity.
      * @param TableModels\TableServiceCreateOptions $options optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/insert-entity
      */
@@ -324,7 +324,7 @@ interface ITable
      * @param TableModels\Entity              $entity  table entity
      * @param TableModels\TableServiceOptions $options optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/hh452241.aspx
      */
@@ -359,7 +359,7 @@ interface ITable
      * @param TableModels\Entity              $entity  table entity
      * @param TableModels\TableServiceOptions $options optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/hh452242.aspx
      */
@@ -395,7 +395,7 @@ interface ITable
      * @param TableModels\Entity              $entity  The table entity.
      * @param TableModels\TableServiceOptions $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179427.aspx
      */
@@ -432,7 +432,7 @@ interface ITable
      * @param TableModels\Entity              $entity  The table entity.
      * @param TableModels\TableServiceOptions $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179392.aspx
      */
@@ -469,7 +469,7 @@ interface ITable
      * @param string                          $rowKey       The entity row key.
      * @param TableModels\DeleteEntityOptions $options      The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd135727.aspx
      */
@@ -515,7 +515,7 @@ interface ITable
      * @param TableModels\GetEntityOptions|null $options      The optional
      *                                                        parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179421.aspx
      */
@@ -545,7 +545,7 @@ interface ITable
      * @param TableModels\BatchOperations     $batchOperations The operations to apply.
      * @param TableModels\TableServiceOptions $options         The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function batchAsync(
         TableModels\BatchOperations $batchOperations,
@@ -573,7 +573,7 @@ interface ITable
      * @param string                          $table   The container name.
      * @param TableModels\TableServiceOptions $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/get-table-acl
      */
@@ -606,7 +606,7 @@ interface ITable
      * @param TableModels\TableACL            $acl     access control list
      * @param TableModels\TableServiceOptions $options optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/set-table-acl
      */

--- a/vendor/microsoft/azure-storage/src/Table/Models/BatchResult.php
+++ b/vendor/microsoft/azure-storage/src/Table/Models/BatchResult.php
@@ -30,7 +30,7 @@ use MicrosoftAzure\Storage\Common\Internal\Http\HttpFormatter;
 use MicrosoftAzure\Storage\Common\Internal\ServiceRestProxy;
 use MicrosoftAzure\Storage\Table\Internal\IMimeReaderWriter;
 use MicrosoftAzure\Storage\Table\Internal\IODataReaderWriter;
-use GuzzleHttp\Psr7\Response;
+use GuzzleHttpLocal\Psr7\Response;
 
 /**
  * Holds results from batch API.

--- a/vendor/microsoft/azure-storage/src/Table/TableRestProxy.php
+++ b/vendor/microsoft/azure-storage/src/Table/TableRestProxy.php
@@ -483,7 +483,7 @@ class TableRestProxy extends ServiceRestProxy implements ITable
      * @param boolean             $useETag The flag to include etag or not.
      * @param TableServiceOptions $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     private function putOrMergeEntityAsyncImpl(
         $table,
@@ -702,7 +702,7 @@ class TableRestProxy extends ServiceRestProxy implements ITable
      *                                                  parameters, table prefix
      *                                                  or filter to apply.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/query-tables
      */
@@ -826,7 +826,7 @@ class TableRestProxy extends ServiceRestProxy implements ITable
      * @param string                    $table   The name of the table.
      * @param TableServiceCreateOptions $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-table
      */
@@ -897,7 +897,7 @@ class TableRestProxy extends ServiceRestProxy implements ITable
      * @param string          $table   The name of the table.
      * @param GetTableOptions $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function getTableAsync(
         $table,
@@ -964,7 +964,7 @@ class TableRestProxy extends ServiceRestProxy implements ITable
      * @param string              $table   The name of the table.
      * @param TableServiceOptions $options optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179387.aspx
      */
@@ -1025,7 +1025,7 @@ class TableRestProxy extends ServiceRestProxy implements ITable
      *                                                    string or filter to
      *                                                    apply.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/query-entities
      */
@@ -1134,7 +1134,7 @@ class TableRestProxy extends ServiceRestProxy implements ITable
      * @param Entity                    $entity  table entity.
      * @param TableServiceCreateOptions $options optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/insert-entity
      */
@@ -1193,7 +1193,7 @@ class TableRestProxy extends ServiceRestProxy implements ITable
      * @param Entity              $entity  table entity
      * @param TableServiceOptions $options optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/hh452241.aspx
      */
@@ -1242,7 +1242,7 @@ class TableRestProxy extends ServiceRestProxy implements ITable
      * @param Entity              $entity  table entity
      * @param TableServiceOptions $options optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/hh452242.aspx
      */
@@ -1288,7 +1288,7 @@ class TableRestProxy extends ServiceRestProxy implements ITable
      * @param Entity              $entity  The table entity.
      * @param TableServiceOptions $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179427.aspx
      */
@@ -1335,7 +1335,7 @@ class TableRestProxy extends ServiceRestProxy implements ITable
      * @param Entity              $entity  The table entity.
      * @param TableServiceOptions $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179392.aspx
      */
@@ -1382,7 +1382,7 @@ class TableRestProxy extends ServiceRestProxy implements ITable
      * @param string              $rowKey       The entity row key.
      * @param DeleteEntityOptions $options      The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd135727.aspx
      */
@@ -1436,7 +1436,7 @@ class TableRestProxy extends ServiceRestProxy implements ITable
      * @param string                $rowKey       The entity row key.
      * @param GetEntityOptions|null $options      The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179421.aspx
      */
@@ -1514,7 +1514,7 @@ class TableRestProxy extends ServiceRestProxy implements ITable
      * @param BatchOperations     $batchOperations The operations to apply.
      * @param TableServiceOptions $options         The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      */
     public function batchAsync(
         Models\BatchOperations $batchOperations,
@@ -1595,7 +1595,7 @@ class TableRestProxy extends ServiceRestProxy implements ITable
      * @param string              $table   The table name.
      * @param TableServiceOptions $options The optional parameters.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/get-table-acl
      */
@@ -1673,7 +1673,7 @@ class TableRestProxy extends ServiceRestProxy implements ITable
      * @param TableACL            $acl     access control list for Table
      * @param TableServiceOptions $options optional parameters
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return \GuzzleHttpLocal\Promise\PromiseInterface
      *
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/set-table-acl
      */

--- a/vendor/microsoft/azure-storage/tests/Framework/TestResources.php
+++ b/vendor/microsoft/azure-storage/tests/Framework/TestResources.php
@@ -32,7 +32,7 @@ use MicrosoftAzure\Storage\Common\Internal\Http\HttpCallContext;
 use MicrosoftAzure\Storage\Table\Models\BatchOperation;
 use MicrosoftAzure\Storage\Table\Models\BatchOperationType;
 use MicrosoftAzure\Storage\Table\Models\UpdateEntityResult;
-use GuzzleHttp\Psr7\Response;
+use GuzzleHttpLocal\Psr7\Response;
 
 /**
  * Resources for testing framework.

--- a/vendor/microsoft/azure-storage/tests/Functional/Blob/BlobServiceFunctionalTest.php
+++ b/vendor/microsoft/azure-storage/tests/Functional/Blob/BlobServiceFunctionalTest.php
@@ -53,10 +53,10 @@ use MicrosoftAzure\Storage\Common\Internal\Utilities;
 use MicrosoftAzure\Storage\Common\Middlewares\RetryMiddlewareFactory;
 use MicrosoftAzure\Storage\Common\Middlewares\HistoryMiddleware;
 use MicrosoftAzure\Storage\Common\LocationMode;
-use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\Client;
+use GuzzleHttpLocal\Exception\RequestException;
+use GuzzleHttpLocal\Handler\MockHandler;
+use GuzzleHttpLocal\Psr7\Response;
+use GuzzleHttpLocal\Client;
 
 class BlobServiceFunctionalTest extends FunctionalTestBase
 {

--- a/vendor/microsoft/azure-storage/tests/Functional/File/FileServiceFunctionalTest.php
+++ b/vendor/microsoft/azure-storage/tests/Functional/File/FileServiceFunctionalTest.php
@@ -42,10 +42,10 @@ use MicrosoftAzure\Storage\Common\Internal\Utilities;
 use MicrosoftAzure\Storage\Common\Middlewares\RetryMiddlewareFactory;
 use MicrosoftAzure\Storage\Common\Middlewares\HistoryMiddleware;
 use MicrosoftAzure\Storage\Common\LocationMode;
-use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\Client;
+use GuzzleHttpLocal\Exception\RequestException;
+use GuzzleHttpLocal\Handler\MockHandler;
+use GuzzleHttpLocal\Psr7\Response;
+use GuzzleHttpLocal\Client;
 
 class FileServiceFunctionalTest extends FunctionalTestBase
 {

--- a/vendor/microsoft/azure-storage/tests/Functional/Queue/QueueServiceFunctionalTest.php
+++ b/vendor/microsoft/azure-storage/tests/Functional/Queue/QueueServiceFunctionalTest.php
@@ -35,9 +35,9 @@ use MicrosoftAzure\Storage\Queue\Models\QueueServiceOptions;
 use MicrosoftAzure\Storage\Common\Middlewares\RetryMiddlewareFactory;
 use MicrosoftAzure\Storage\Common\Middlewares\HistoryMiddleware;
 use MicrosoftAzure\Storage\Common\LocationMode;
-use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\Psr7\Response;
+use GuzzleHttpLocal\Exception\RequestException;
+use GuzzleHttpLocal\Handler\MockHandler;
+use GuzzleHttpLocal\Psr7\Response;
 
 class QueueServiceFunctionalTest extends FunctionalTestBase
 {

--- a/vendor/microsoft/azure-storage/tests/Functional/Table/TableServiceFunctionalTest.php
+++ b/vendor/microsoft/azure-storage/tests/Functional/Table/TableServiceFunctionalTest.php
@@ -48,9 +48,9 @@ use MicrosoftAzure\Storage\Table\Models\UpdateEntityResult;
 use MicrosoftAzure\Storage\Common\Middlewares\RetryMiddlewareFactory;
 use MicrosoftAzure\Storage\Common\Middlewares\HistoryMiddleware;
 use MicrosoftAzure\Storage\Common\LocationMode;
-use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\Psr7\Response;
+use GuzzleHttpLocal\Exception\RequestException;
+use GuzzleHttpLocal\Handler\MockHandler;
+use GuzzleHttpLocal\Psr7\Response;
 
 class TableServiceFunctionalTest extends FunctionalTestBase
 {

--- a/vendor/microsoft/azure-storage/tests/Unit/Blob/Models/GetBlobResultTest.php
+++ b/vendor/microsoft/azure-storage/tests/Unit/Blob/Models/GetBlobResultTest.php
@@ -27,7 +27,7 @@ use MicrosoftAzure\Storage\Common\Internal\Utilities;
 use MicrosoftAzure\Storage\Blob\Models\GetBlobResult;
 use MicrosoftAzure\Storage\Blob\Models\BlobProperties;
 use MicrosoftAzure\Storage\Tests\Framework\TestResources;
-use GuzzleHttp\Psr7;
+use GuzzleHttpLocal\Psr7;
 
 /**
  * Unit tests for class GetBlobResult

--- a/vendor/microsoft/azure-storage/tests/Unit/Common/Internal/Authentication/SharedAccessSignatureAuthSchemeTest.php
+++ b/vendor/microsoft/azure-storage/tests/Unit/Common/Internal/Authentication/SharedAccessSignatureAuthSchemeTest.php
@@ -24,8 +24,8 @@
 
 namespace MicrosoftAzure\Storage\Tests\Unit\Common\Internal\Authentication;
 
-use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Psr7\Uri;
+use GuzzleHttpLocal\Psr7\Request;
+use GuzzleHttpLocal\Psr7\Uri;
 use MicrosoftAzure\Storage\Common\Internal\Authentication\SharedAccessSignatureAuthScheme;
 use MicrosoftAzure\Storage\Common\Internal\ServiceRestProxy;
 use MicrosoftAzure\Storage\Tests\Unit\Utilities;

--- a/vendor/microsoft/azure-storage/tests/Unit/Common/Internal/Authentication/SharedKeyAuthSchemeTest.php
+++ b/vendor/microsoft/azure-storage/tests/Unit/Common/Internal/Authentication/SharedKeyAuthSchemeTest.php
@@ -24,8 +24,8 @@
 
 namespace MicrosoftAzure\Storage\Tests\Unit\Common\Internal\Authentication;
 
-use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Psr7\Uri;
+use GuzzleHttpLocal\Psr7\Request;
+use GuzzleHttpLocal\Psr7\Uri;
 use MicrosoftAzure\Storage\Tests\Mock\Common\Internal\Authentication\SharedKeyAuthSchemeMock;
 use MicrosoftAzure\Storage\Common\Internal\Resources;
 use MicrosoftAzure\Storage\Common\Internal\ServiceRestProxy;

--- a/vendor/microsoft/azure-storage/tests/Unit/Common/Internal/Middlewares/CommonRequestMiddlewareTest.php
+++ b/vendor/microsoft/azure-storage/tests/Unit/Common/Internal/Middlewares/CommonRequestMiddlewareTest.php
@@ -28,8 +28,8 @@ use MicrosoftAzure\Storage\Common\Internal\Middlewares\CommonRequestMiddleware;
 use MicrosoftAzure\Storage\Common\Internal\Authentication\SharedKeyAuthScheme;
 use MicrosoftAzure\Storage\Common\Internal\Resources;
 use MicrosoftAzure\Storage\Tests\Framework\ReflectionTestBase;
-use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\Request;
+use GuzzleHttpLocal\Exception\RequestException;
+use GuzzleHttpLocal\Psr7\Request;
 
 /**
  * Unit tests for class CommonRequestMiddleware

--- a/vendor/microsoft/azure-storage/tests/Unit/Common/Internal/ServiceRestProxyTest.php
+++ b/vendor/microsoft/azure-storage/tests/Unit/Common/Internal/ServiceRestProxyTest.php
@@ -24,10 +24,10 @@
 
 namespace MicrosoftAzure\Storage\Tests\Unit\Common\Internal;
 
-use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Request;
+use GuzzleHttpLocal\Exception\RequestException;
+use GuzzleHttpLocal\Handler\MockHandler;
+use GuzzleHttpLocal\HandlerStack;
+use GuzzleHttpLocal\Psr7\Request;
 use MicrosoftAzure\Storage\Common\Internal\ServiceRestProxy;
 use MicrosoftAzure\Storage\Common\Internal\Resources;
 use MicrosoftAzure\Storage\Tests\Mock\Common\Internal\Filters\SimpleFilterMock;

--- a/vendor/microsoft/azure-storage/tests/Unit/Common/Internal/UtilitiesTest.php
+++ b/vendor/microsoft/azure-storage/tests/Unit/Common/Internal/UtilitiesTest.php
@@ -30,7 +30,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
 use MicrosoftAzure\Storage\Tests\Framework\VirtualFileSystem;
 use MicrosoftAzure\Storage\Common\Models\ServiceProperties;
 use MicrosoftAzure\Storage\Common\Internal\Serialization\XmlSerializer;
-use GuzzleHttp\Psr7;
+use GuzzleHttpLocal\Psr7;
 
 /**
  * Unit tests for class Utilities

--- a/vendor/microsoft/azure-storage/tests/Unit/Common/Middlewares/HistoryMiddlewareTest.php
+++ b/vendor/microsoft/azure-storage/tests/Unit/Common/Middlewares/HistoryMiddlewareTest.php
@@ -26,9 +26,9 @@ namespace MicrosoftAzure\Storage\Tests\Unit\Common\Middlewares;
 
 use MicrosoftAzure\Storage\Common\Middlewares\HistoryMiddleware;
 use MicrosoftAzure\Storage\Tests\Framework\ReflectionTestBase;
-use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\Psr7\Request;
+use GuzzleHttpLocal\Exception\RequestException;
+use GuzzleHttpLocal\Psr7\Response;
+use GuzzleHttpLocal\Psr7\Request;
 
 /**
  * Unit tests for class HistoryMiddleware

--- a/vendor/microsoft/azure-storage/tests/Unit/Common/Middlewares/MiddlewareBaseTest.php
+++ b/vendor/microsoft/azure-storage/tests/Unit/Common/Middlewares/MiddlewareBaseTest.php
@@ -26,10 +26,10 @@ namespace MicrosoftAzure\Storage\Tests\Unit\Common\Middlewares;
 
 use MicrosoftAzure\Storage\Common\Middlewares\MiddlewareBase;
 use MicrosoftAzure\Storage\Tests\Framework\ReflectionTestBase;
-use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Client;
+use GuzzleHttpLocal\Exception\RequestException;
+use GuzzleHttpLocal\Psr7\Response;
+use GuzzleHttpLocal\Psr7\Request;
+use GuzzleHttpLocal\Client;
 
 /**
  * Unit tests for class MiddlewareBase

--- a/vendor/microsoft/azure-storage/tests/Unit/Common/Middlewares/RetryMiddlewareFactoryTest.php
+++ b/vendor/microsoft/azure-storage/tests/Unit/Common/Middlewares/RetryMiddlewareFactoryTest.php
@@ -27,8 +27,8 @@ namespace MicrosoftAzure\Storage\Tests\Unit\Common\Middlewares;
 use MicrosoftAzure\Storage\Common\Middlewares\RetryMiddlewareFactory;
 use MicrosoftAzure\Storage\Common\Internal\Resources;
 use MicrosoftAzure\Storage\Tests\Framework\ReflectionTestBase;
-use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\Psr7\Request;
+use GuzzleHttpLocal\Psr7\Response;
+use GuzzleHttpLocal\Psr7\Request;
 
 class RetryMiddlewareFactoryTest extends ReflectionTestBase
 {


### PR DESCRIPTION
Closes #3 

**Changes**
- Replace all `GuzzleHttp` references with `GuzzleHttpLocal` to stop it conflicting with core moodle guzzle. Updated composers class maps so it maps correctly.
- Updated readme with note about upstream lib deprecation

Note - This is not intended to be a long term solution, but will extend the life of this plugin a bit longer while we properly deprecate/migrate it to something else.

**Why is this necessary**
Guzzle in moodle core uses a higher version and has breaking api changes with the Guzzle installed here, hence we cannot just remove the local guzzle and use cores. Another option is to do this but then go in and fix all the breaking api changes, but that seems more error prone and more effort than just loading both in parallel.

**Testing**
- On my local I have azure storage setup, and the permissions check + read/write check passes (in the objectfs plugin settings) indicating it is successfully reading and writing files to azure storage.
- The objectfs unit tests pass, however, i'm unsure how many of these tests touch this sdk code.
- Ran a test from the testing instructions here https://tracker.moodle.org/browse/MDL-76135 to confirm core guzzle is unaffected

**To do**
- [x] Make 4.2 branch and retarget this PR to it
- [x] After merging - cherry pick readme commit to the `master` branch